### PR TITLE
Fixed ERC Errors

### DIFF
--- a/TransceiverPCB/#auto_saved_files#
+++ b/TransceiverPCB/#auto_saved_files#
@@ -1,0 +1,1 @@
+/Users/joaquincaraveo/Desktop/CommunicationSystems/TransceiverPCB/_autosave-TransceiverPCB.kicad_sch

--- a/TransceiverPCB/LIB_IRISHSAT.bak
+++ b/TransceiverPCB/LIB_IRISHSAT.bak
@@ -25,7 +25,7 @@
 				)
 			)
 		)
-		(property "Footprint" "CONN14_878321420_MOL"
+		(property "Footprint" "LIB_IRISHSAT:CONN14_878321420_MOL"
 			(at 0 0 0)
 			(effects
 				(font
@@ -52,14 +52,6 @@
 					(size 1.27 1.27)
 				)
 				(hide yes)
-			)
-		)
-		(property "ki_locked" ""
-			(at 0 0 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
 			)
 		)
 		(property "ki_keywords" "878321420"

--- a/TransceiverPCB/LIB_IRISHSAT.kicad_sym
+++ b/TransceiverPCB/LIB_IRISHSAT.kicad_sym
@@ -9023,24 +9023,6 @@
 					)
 				)
 			)
-			(pin power_out line
-				(at 0 -2.54 0)
-				(length 7.62)
-				(name "GND"
-					(effects
-						(font
-							(size 1.27 1.27)
-						)
-					)
-				)
-				(number "2"
-					(effects
-						(font
-							(size 1.27 1.27)
-						)
-					)
-				)
-			)
 			(pin power_in line
 				(at 49.53 0 180)
 				(length 7.62)
@@ -9084,6 +9066,24 @@
 				(effects
 					(font
 						(size 2.54 2.54)
+					)
+				)
+			)
+			(pin passive line
+				(at 0 -2.54 0)
+				(length 7.62)
+				(name "GND"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
 					)
 				)
 			)

--- a/TransceiverPCB/TransceiverPCB.kicad_sch
+++ b/TransceiverPCB/TransceiverPCB.kicad_sch
@@ -147,6 +147,218 @@
 			)
 			(embedded_fonts no)
 		)
+		(symbol "DSC1001CI2-100.0000T_1"
+			(pin_names
+				(offset 0.254)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "U4"
+				(at 22.86 10.16 0)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+				)
+			)
+			(property "Value" "DSC1001CI2-100.0000T"
+				(at 22.86 7.62 0)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+				)
+			)
+			(property "Footprint" "LIB_IRISHSAT:CDFN4_3P2X2P5_MCH"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+						(italic yes)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "DSC1001CI2-100.0000T"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+						(italic yes)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_locked" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "DSC1001CI2-100.0000T"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "CDFN4_3P2X2P5_MCH CDFN4_3P2X2P5_MCH-M CDFN4_3P2X2P5_MCH-L"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "DSC1001CI2-100.0000T_1_0_1"
+				(polyline
+					(pts
+						(xy 7.62 5.08) (xy 7.62 -7.62)
+					)
+					(stroke
+						(width 0.127)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 7.62 -7.62) (xy 41.91 -7.62)
+					)
+					(stroke
+						(width 0.127)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 41.91 5.08) (xy 7.62 5.08)
+					)
+					(stroke
+						(width 0.127)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 41.91 -7.62) (xy 41.91 5.08)
+					)
+					(stroke
+						(width 0.127)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(pin input line
+					(at 0 0 0)
+					(length 7.62)
+					(name "*STANDBY"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 49.53 0 180)
+					(length 7.62)
+					(name "VDD"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin output line
+					(at 49.53 -2.54 180)
+					(length 7.62)
+					(name "OUT"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(symbol "DSC1001CI2-100.0000T_1_1_1"
+				(text "Crystal\nOscillator\n100MHz"
+					(at 26.416 -1.016 0)
+					(effects
+						(font
+							(size 2.54 2.54)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -2.54 0)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
 		(symbol "Device:C"
 			(pin_numbers
 				(hide yes)
@@ -4522,7 +4734,7 @@
 			(exclude_from_sim no)
 			(in_bom yes)
 			(on_board yes)
-			(property "Reference" "U"
+			(property "Reference" "U7"
 				(at 25.4 10.16 0)
 				(effects
 					(font
@@ -4538,7 +4750,7 @@
 					)
 				)
 			)
-			(property "Footprint" "CP_24_7_ADI"
+			(property "Footprint" "LIB_IRISHSAT:CP_24_7_ADI"
 				(at 0 0 0)
 				(effects
 					(font
@@ -4823,24 +5035,6 @@
 					)
 				)
 				(pin output line
-					(at 0 -25.4 0)
-					(length 7.62)
-					(name "VOCM2"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "11"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin output line
 					(at 0 -27.94 0)
 					(length 7.62)
 					(name "OUT2+"
@@ -5002,24 +5196,6 @@
 						)
 					)
 				)
-				(pin output line
-					(at 50.8 -20.32 180)
-					(length 7.62)
-					(name "VOCM1"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "17"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
 				(pin power_in line
 					(at 50.8 -22.86 180)
 					(length 7.62)
@@ -5099,6 +5275,42 @@
 					(effects
 						(font
 							(size 2.54 2.54)
+						)
+					)
+				)
+				(pin input line
+					(at 0 -25.4 0)
+					(length 7.62)
+					(name "VOCM2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at 50.8 -20.32 180)
+					(length 7.62)
+					(name "VOCM1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "17"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
 						)
 					)
 				)
@@ -6654,7 +6866,7 @@
 			(exclude_from_sim no)
 			(in_bom yes)
 			(on_board yes)
-			(property "Reference" "U"
+			(property "Reference" "U12"
 				(at 20.32 10.16 0)
 				(effects
 					(font
@@ -6670,7 +6882,7 @@
 					)
 				)
 			)
-			(property "Footprint" "CP-24-14_ADI"
+			(property "Footprint" "LIB_IRISHSAT:CP-24-14_ADI"
 				(at 0 0 0)
 				(effects
 					(font
@@ -6784,24 +6996,6 @@
 						)
 					)
 				)
-				(pin power_out line
-					(at 0 -2.54 0)
-					(length 7.62)
-					(name "COM"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "2"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
 				(pin unspecified line
 					(at 0 -5.08 0)
 					(length 7.62)
@@ -6874,24 +7068,6 @@
 						)
 					)
 				)
-				(pin power_out line
-					(at 0 -15.24 0)
-					(length 7.62)
-					(name "CML"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "7"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
 				(pin input line
 					(at 0 -17.78 0)
 					(length 7.62)
@@ -6928,114 +7104,6 @@
 						)
 					)
 				)
-				(pin power_out line
-					(at 0 -22.86 0)
-					(length 7.62)
-					(name "CML"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "10"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin power_out line
-					(at 0 -25.4 0)
-					(length 7.62)
-					(name "CML"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "11"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin power_out line
-					(at 0 -27.94 0)
-					(length 7.62)
-					(name "COM"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "12"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin power_out line
-					(at 40.64 0 180)
-					(length 7.62)
-					(name "GND"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "25"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin power_out line
-					(at 40.64 -2.54 180)
-					(length 7.62)
-					(name "CMRF"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "24"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin power_out line
-					(at 40.64 -5.08 180)
-					(length 7.62)
-					(name "CMRF"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "23"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
 				(pin input line
 					(at 40.64 -7.62 180)
 					(length 7.62)
@@ -7065,24 +7133,6 @@
 						)
 					)
 					(number "21"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin power_out line
-					(at 40.64 -12.7 180)
-					(length 7.62)
-					(name "CMRF"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "20"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -7223,6 +7273,168 @@
 					(effects
 						(font
 							(size 1.27 1.27)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -2.54 0)
+					(length 7.62)
+					(name "COM"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -15.24 0)
+					(length 7.62)
+					(name "CML"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -22.86 0)
+					(length 7.62)
+					(name "CML"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -25.4 0)
+					(length 7.62)
+					(name "CML"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -27.94 0)
+					(length 7.62)
+					(name "COM"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 40.64 0 180)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "25"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 40.64 -2.54 180)
+					(length 7.62)
+					(name "CMRF"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "24"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 40.64 -5.08 180)
+					(length 7.62)
+					(name "CMRF"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "23"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 40.64 -12.7 180)
+					(length 7.62)
+					(name "CMRF"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "20"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
 						)
 					)
 				)
@@ -8034,7 +8246,7 @@
 			(exclude_from_sim no)
 			(in_bom yes)
 			(on_board yes)
-			(property "Reference" "U"
+			(property "Reference" "U14"
 				(at 22.86 10.16 0)
 				(effects
 					(font
@@ -8050,7 +8262,7 @@
 					)
 				)
 			)
-			(property "Footprint" "CDFN4_3P2X2P5_MCH"
+			(property "Footprint" "LIB_IRISHSAT:CDFN4_3P2X2P5_MCH"
 				(at 0 0 0)
 				(effects
 					(font
@@ -8172,24 +8384,6 @@
 						)
 					)
 				)
-				(pin power_out line
-					(at 0 -2.54 0)
-					(length 7.62)
-					(name "GND"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "2"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
 				(pin power_in line
 					(at 49.53 0 180)
 					(length 7.62)
@@ -8233,6 +8427,24 @@
 					(effects
 						(font
 							(size 2.54 2.54)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -2.54 0)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
 						)
 					)
 				)
@@ -9706,8 +9918,8 @@
 			(exclude_from_sim no)
 			(in_bom yes)
 			(on_board yes)
-			(property "Reference" "U"
-				(at 34.29 -9.144 0)
+			(property "Reference" "U9"
+				(at 30.48 10.16 0)
 				(effects
 					(font
 						(size 1.524 1.524)
@@ -9715,15 +9927,15 @@
 				)
 			)
 			(property "Value" "SC09147"
-				(at 34.29 -11.684 0)
+				(at 30.48 7.62 0)
 				(effects
 					(font
 						(size 1.524 1.524)
 					)
 				)
 			)
-			(property "Footprint" "QFN56_7X7_RPI"
-				(at 63.5 21.59 0)
+			(property "Footprint" "LIB_IRISHSAT:QFN56_7X7_RPI"
+				(at 0 0 0)
 				(effects
 					(font
 						(size 1.27 1.27)
@@ -9733,7 +9945,7 @@
 				)
 			)
 			(property "Datasheet" "SC09147"
-				(at 63.5 21.59 0)
+				(at 0 0 0)
 				(effects
 					(font
 						(size 1.27 1.27)
@@ -10071,24 +10283,6 @@
 						)
 					)
 					(number "19"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin power_out line
-					(at 0 -57.15 0)
-					(length 7.62)
-					(name "GND"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "57"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -10862,6 +11056,24 @@
 						)
 					)
 				)
+				(pin passive line
+					(at 0 -57.15 0)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "57"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
 			)
 			(embedded_fonts no)
 		)
@@ -10872,7 +11084,7 @@
 			(exclude_from_sim no)
 			(in_bom yes)
 			(on_board yes)
-			(property "Reference" "U"
+			(property "Reference" "U15"
 				(at 20.32 10.16 0)
 				(effects
 					(font
@@ -10982,24 +11194,6 @@
 					)
 					(fill
 						(type none)
-					)
-				)
-				(pin power_out line
-					(at 0 0 0)
-					(length 7.62)
-					(name "GND"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "1"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
 					)
 				)
 				(pin unspecified line
@@ -11146,6 +11340,24 @@
 						)
 					)
 				)
+				(pin passive line
+					(at 0 0 0)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
 			)
 			(embedded_fonts no)
 		)
@@ -11156,7 +11368,7 @@
 			(exclude_from_sim no)
 			(in_bom yes)
 			(on_board yes)
-			(property "Reference" "U"
+			(property "Reference" "U16"
 				(at 20.32 10.16 0)
 				(effects
 					(font
@@ -11266,24 +11478,6 @@
 					)
 					(fill
 						(type none)
-					)
-				)
-				(pin power_out line
-					(at 0 0 0)
-					(length 7.62)
-					(name "GND"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "1"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
 					)
 				)
 				(pin unspecified line
@@ -11430,6 +11624,24 @@
 						)
 					)
 				)
+				(pin passive line
+					(at 0 0 0)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
 			)
 			(embedded_fonts no)
 		)
@@ -11440,7 +11652,7 @@
 			(exclude_from_sim no)
 			(in_bom yes)
 			(on_board yes)
-			(property "Reference" "U"
+			(property "Reference" "U13"
 				(at 20.32 10.16 0)
 				(effects
 					(font
@@ -11606,24 +11818,6 @@
 						)
 					)
 				)
-				(pin power_out line
-					(at 0 -7.62 0)
-					(length 7.62)
-					(name "GND"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "4"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
 				(pin unspecified line
 					(at 40.64 0 180)
 					(length 7.62)
@@ -11689,6 +11883,26 @@
 						)
 					)
 					(number "5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(symbol "TPS62933FDRLR_1_1"
+				(pin passive line
+					(at 0 -7.62 0)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "4"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -12386,8 +12600,8 @@
 			(exclude_from_sim no)
 			(in_bom yes)
 			(on_board yes)
-			(property "Reference" "U"
-				(at 39.878 6.35 0)
+			(property "Reference" "U3"
+				(at 40.64 10.16 0)
 				(effects
 					(font
 						(size 1.524 1.524)
@@ -12395,14 +12609,14 @@
 				)
 			)
 			(property "Value" "W25Q32JVSSIQ"
-				(at 27.94 6.604 0)
+				(at 40.64 7.62 0)
 				(effects
 					(font
 						(size 1.524 1.524)
 					)
 				)
 			)
-			(property "Footprint" "SOIC-8_5P28X5P28_WIN"
+			(property "Footprint" "LIB_IRISHSAT:SOIC-8_5P28X5P28_WIN"
 				(at 0 0 0)
 				(effects
 					(font
@@ -12560,24 +12774,6 @@
 						)
 					)
 				)
-				(pin power_out line
-					(at 0 -5.08 0)
-					(length 7.62)
-					(name "GND"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "4"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
 				(pin power_in line
 					(at 63.5 2.54 180)
 					(length 7.62)
@@ -12660,6 +12856,24 @@
 						)
 					)
 				)
+				(pin passive line
+					(at 0 -5.08 0)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
 			)
 			(embedded_fonts no)
 		)
@@ -12670,8 +12884,8 @@
 			(exclude_from_sim no)
 			(in_bom yes)
 			(on_board yes)
-			(property "Reference" "U"
-				(at 38.608 10.16 0)
+			(property "Reference" "U1"
+				(at 58.42 10.16 0)
 				(effects
 					(font
 						(size 1.524 1.524)
@@ -12679,14 +12893,14 @@
 				)
 			)
 			(property "Value" "XC7A35T-1FTG256C"
-				(at 39.37 7.62 0)
+				(at 58.42 7.62 0)
 				(effects
 					(font
 						(size 1.524 1.524)
 					)
 				)
 			)
-			(property "Footprint" "FT/FTG256ARTIX-7_AMD"
+			(property "Footprint" "LIB_IRISHSAT:FT&slash_FTG256ARTIX-7_AMD"
 				(at 0 0 0)
 				(effects
 					(font
@@ -12798,7 +13012,7 @@
 						)
 					)
 				)
-				(pin power_out line
+				(pin passive line
 					(at 0 0 0)
 					(length 7.62)
 					(name "GND"
@@ -12978,7 +13192,7 @@
 						)
 					)
 				)
-				(pin power_out line
+				(pin passive line
 					(at 0 -25.4 0)
 					(length 7.62)
 					(name "GND"
@@ -13212,7 +13426,7 @@
 						)
 					)
 				)
-				(pin power_out line
+				(pin passive line
 					(at 0 -58.42 0)
 					(length 7.62)
 					(name "GND"
@@ -13446,7 +13660,7 @@
 						)
 					)
 				)
-				(pin power_out line
+				(pin passive line
 					(at 0 -91.44 0)
 					(length 7.62)
 					(name "GND"
@@ -13572,7 +13786,7 @@
 						)
 					)
 				)
-				(pin power_out line
+				(pin passive line
 					(at 73.66 0 180)
 					(length 7.62)
 					(name "GND"
@@ -13806,7 +14020,7 @@
 						)
 					)
 				)
-				(pin power_out line
+				(pin passive line
 					(at 73.66 -33.02 180)
 					(length 7.62)
 					(name "GND"
@@ -14040,7 +14254,7 @@
 						)
 					)
 				)
-				(pin power_out line
+				(pin passive line
 					(at 73.66 -66.04 180)
 					(length 7.62)
 					(name "GND"
@@ -14220,7 +14434,7 @@
 						)
 					)
 				)
-				(pin power_out line
+				(pin passive line
 					(at 73.66 -91.44 180)
 					(length 7.62)
 					(name "GND"
@@ -14274,7 +14488,7 @@
 						)
 					)
 				)
-				(pin power_out line
+				(pin passive line
 					(at 73.66 -99.06 180)
 					(length 7.62)
 					(name "GND"
@@ -14458,7 +14672,7 @@
 						)
 					)
 				)
-				(pin power_out line
+				(pin passive line
 					(at 0 -7.62 0)
 					(length 7.62)
 					(name "GND"
@@ -14566,7 +14780,7 @@
 						)
 					)
 				)
-				(pin power_out line
+				(pin passive line
 					(at 0 -22.86 0)
 					(length 7.62)
 					(name "GND"
@@ -14620,7 +14834,7 @@
 						)
 					)
 				)
-				(pin power_out line
+				(pin passive line
 					(at 0 -30.48 0)
 					(length 7.62)
 					(name "GND"
@@ -14692,7 +14906,7 @@
 						)
 					)
 				)
-				(pin power_out line
+				(pin passive line
 					(at 0 -40.64 0)
 					(length 7.62)
 					(name "GNDADC_0"
@@ -14728,7 +14942,7 @@
 						)
 					)
 				)
-				(pin power_out line
+				(pin passive line
 					(at 0 -45.72 0)
 					(length 7.62)
 					(name "GND"
@@ -14800,7 +15014,7 @@
 						)
 					)
 				)
-				(pin power_out line
+				(pin passive line
 					(at 0 -55.88 0)
 					(length 7.62)
 					(name "GND"
@@ -14962,7 +15176,7 @@
 						)
 					)
 				)
-				(pin power_out line
+				(pin passive line
 					(at 0 -78.74 0)
 					(length 7.62)
 					(name "GND"
@@ -15196,7 +15410,7 @@
 						)
 					)
 				)
-				(pin power_out line
+				(pin passive line
 					(at 62.23 -2.54 180)
 					(length 7.62)
 					(name "GND"
@@ -15376,7 +15590,7 @@
 						)
 					)
 				)
-				(pin power_out line
+				(pin passive line
 					(at 62.23 -27.94 180)
 					(length 7.62)
 					(name "GND"
@@ -15430,7 +15644,7 @@
 						)
 					)
 				)
-				(pin power_out line
+				(pin passive line
 					(at 62.23 -35.56 180)
 					(length 7.62)
 					(name "GND"
@@ -15574,7 +15788,7 @@
 						)
 					)
 				)
-				(pin power_out line
+				(pin passive line
 					(at 62.23 -55.88 180)
 					(length 7.62)
 					(name "GND"
@@ -15610,7 +15824,7 @@
 						)
 					)
 				)
-				(pin power_out line
+				(pin passive line
 					(at 62.23 -60.96 180)
 					(length 7.62)
 					(name "GND"
@@ -15772,7 +15986,7 @@
 						)
 					)
 				)
-				(pin power_out line
+				(pin passive line
 					(at 62.23 -83.82 180)
 					(length 7.62)
 					(name "GND"
@@ -15808,7 +16022,7 @@
 						)
 					)
 				)
-				(pin power_out line
+				(pin passive line
 					(at 62.23 -88.9 180)
 					(length 7.62)
 					(name "GND"
@@ -16208,7 +16422,7 @@
 						)
 					)
 				)
-				(pin power_out line
+				(pin passive line
 					(at 0 -27.94 0)
 					(length 7.62)
 					(name "GND"
@@ -16442,7 +16656,7 @@
 						)
 					)
 				)
-				(pin power_out line
+				(pin passive line
 					(at 0 -60.96 0)
 					(length 7.62)
 					(name "GND"
@@ -16622,7 +16836,7 @@
 						)
 					)
 				)
-				(pin power_out line
+				(pin passive line
 					(at 0 -86.36 0)
 					(length 7.62)
 					(name "GND"
@@ -16676,7 +16890,7 @@
 						)
 					)
 				)
-				(pin power_out line
+				(pin passive line
 					(at 0 -93.98 0)
 					(length 7.62)
 					(name "GND"
@@ -16784,7 +16998,7 @@
 						)
 					)
 				)
-				(pin power_out line
+				(pin passive line
 					(at 83.82 -5.08 180)
 					(length 7.62)
 					(name "GND"
@@ -16964,7 +17178,7 @@
 						)
 					)
 				)
-				(pin power_out line
+				(pin passive line
 					(at 83.82 -30.48 180)
 					(length 7.62)
 					(name "GND"
@@ -17198,7 +17412,7 @@
 						)
 					)
 				)
-				(pin power_out line
+				(pin passive line
 					(at 83.82 -63.5 180)
 					(length 7.62)
 					(name "GND"
@@ -17432,7 +17646,7 @@
 						)
 					)
 				)
-				(pin power_out line
+				(pin passive line
 					(at 83.82 -96.52 180)
 					(length 7.62)
 					(name "GND"
@@ -17665,6 +17879,290 @@
 						)
 					)
 					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "TPS62840DLCR_1"
+			(pin_names
+				(offset 0.254)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "U11"
+				(at 20.32 10.16 0)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+				)
+			)
+			(property "Value" "TPS62840DLCR"
+				(at 20.32 7.62 0)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+				)
+			)
+			(property "Footprint" "LIB_IRISHSAT:VSON8_2P1X1P6_TEX"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+						(italic yes)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "https://www.ti.com/lit/gpn/tps62840"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+						(italic yes)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "TPS62840DLCR"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "VSON8_2P1X1P6_TEX VSON8_2P1X1P6_TEX-M VSON8_2P1X1P6_TEX-L"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "TPS62840DLCR_1_0_1"
+				(polyline
+					(pts
+						(xy 7.62 5.08) (xy 7.62 -12.7)
+					)
+					(stroke
+						(width 0.127)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 7.62 -12.7) (xy 33.02 -12.7)
+					)
+					(stroke
+						(width 0.127)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 33.02 5.08) (xy 7.62 5.08)
+					)
+					(stroke
+						(width 0.127)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 33.02 -12.7) (xy 33.02 5.08)
+					)
+					(stroke
+						(width 0.127)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(pin unspecified line
+					(at 0 -2.54 0)
+					(length 7.62)
+					(name "VIN"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin unspecified line
+					(at 0 -5.08 0)
+					(length 7.62)
+					(name "MODE"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin unspecified line
+					(at 0 -7.62 0)
+					(length 7.62)
+					(name "EN"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin unspecified line
+					(at 40.64 0 180)
+					(length 7.62)
+					(name "VOS"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin unspecified line
+					(at 40.64 -2.54 180)
+					(length 7.62)
+					(name "SW"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin unspecified line
+					(at 40.64 -5.08 180)
+					(length 7.62)
+					(name "STOP"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin unspecified line
+					(at 40.64 -7.62 180)
+					(length 7.62)
+					(name "VSET"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(symbol "TPS62840DLCR_1_1_1"
+				(text "VSET -> GND\n+1V8"
+					(at 19.05 -9.906 0)
+					(effects
+						(font
+							(size 0.762 0.762)
+						)
+					)
+				)
+				(text "VSET -> 52.3k -> GND\n+3V0"
+					(at 20.32 2.032 0)
+					(effects
+						(font
+							(size 0.762 0.762)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 0 0)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -17963,6 +18461,10014 @@
 						)
 					)
 					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "W25Q32JVSSIQ_1"
+			(pin_names
+				(offset 0.254)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "U2"
+				(at 40.64 10.16 0)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+				)
+			)
+			(property "Value" "W25Q32JVSSIQ"
+				(at 40.64 7.62 0)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+				)
+			)
+			(property "Footprint" "LIB_IRISHSAT:SOIC-8_5P28X5P28_WIN"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+						(italic yes)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "W25Q32JVSSIQ"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+						(italic yes)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_locked" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "W25Q32JVSSIQ"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "SOIC-8_5P28X5P28_WIN SOIC-8_5P28X5P28_WIN-M SOIC-8_5P28X5P28_WIN-L"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "W25Q32JVSSIQ_1_0_1"
+				(polyline
+					(pts
+						(xy 7.62 5.08) (xy 7.62 -7.62)
+					)
+					(stroke
+						(width 0.127)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 7.62 -7.62) (xy 55.88 -7.62)
+					)
+					(stroke
+						(width 0.127)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 55.88 5.08) (xy 7.62 5.08)
+					)
+					(stroke
+						(width 0.127)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 55.88 -7.62) (xy 55.88 5.08)
+					)
+					(stroke
+						(width 0.127)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(pin unspecified line
+					(at 0 2.54 0)
+					(length 7.62)
+					(name "/CS"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin unspecified line
+					(at 0 0 0)
+					(length 7.62)
+					(name "DO(IO1)"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin unspecified line
+					(at 0 -2.54 0)
+					(length 7.62)
+					(name "/WP(IO2)"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 63.5 2.54 180)
+					(length 7.62)
+					(name "VCC"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin unspecified line
+					(at 63.5 0 180)
+					(length 7.62)
+					(name "/HOLD_OR_/RESET(IO3)"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin unspecified line
+					(at 63.5 -2.54 180)
+					(length 7.62)
+					(name "CLK"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin unspecified line
+					(at 63.5 -5.08 180)
+					(length 7.62)
+					(name "DI(IO0)"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(symbol "W25Q32JVSSIQ_1_1_1"
+				(text "FLASH\nMEMORY"
+					(at 25.4 -1.27 0)
+					(effects
+						(font
+							(size 2.54 2.54)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -5.08 0)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "XC7A35T-1FTG256C_1"
+			(pin_names
+				(offset 0.254)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "U1"
+				(at 58.42 10.16 0)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+				)
+			)
+			(property "Value" "XC7A35T-1FTG256C"
+				(at 58.42 7.62 0)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+				)
+			)
+			(property "Footprint" "LIB_IRISHSAT:FT&slash_FTG256ARTIX-7_AMD"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+						(italic yes)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "XC7A35T-1FTG256C"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+						(italic yes)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_locked" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "XC7A35T-1FTG256C"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "FT/FTG256ARTIX-7_AMD FT/FTG256ARTIX-7_AMD-M FT/FTG256ARTIX-7_AMD-L"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "XC7A35T-1FTG256C_1_1_1"
+				(polyline
+					(pts
+						(xy 7.62 5.08) (xy 7.62 -111.76)
+					)
+					(stroke
+						(width 0.127)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 7.62 -111.76) (xy 66.04 -111.76)
+					)
+					(stroke
+						(width 0.127)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 66.04 5.08) (xy 7.62 5.08)
+					)
+					(stroke
+						(width 0.127)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 66.04 -111.76) (xy 66.04 5.08)
+					)
+					(stroke
+						(width 0.127)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(text "FPGA\nA"
+					(at 38.862 -41.91 0)
+					(effects
+						(font
+							(size 2.54 2.54)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 0 0)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -2.54 0)
+					(length 7.62)
+					(name "IO_L8N_T1_AD14N_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -5.08 0)
+					(length 7.62)
+					(name "IO_L4N_T0_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -7.62 0)
+					(length 7.62)
+					(name "IO_L3N_T0_DQS_AD5N_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -10.16 0)
+					(length 7.62)
+					(name "IO_L3P_T0_DQS_AD5P_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 -12.7 0)
+					(length 7.62)
+					(name "VCCO_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -15.24 0)
+					(length 7.62)
+					(name "IO_L1N_T0_AD4N_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -17.78 0)
+					(length 7.62)
+					(name "IO_L2P_T0_AD8P_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -20.32 0)
+					(length 7.62)
+					(name "IO_L2N_T0_AD8N_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -22.86 0)
+					(length 7.62)
+					(name "IO_L3N_T0_DQS_AD1N_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -25.4 0)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -27.94 0)
+					(length 7.62)
+					(name "IO_L5N_T0_AD9N_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -30.48 0)
+					(length 7.62)
+					(name "IO_L7P_T1_AD2P_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -33.02 0)
+					(length 7.62)
+					(name "IO_L7N_T1_AD2N_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -35.56 0)
+					(length 7.62)
+					(name "IO_L9N_T1_DQS_AD3N_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 -38.1 0)
+					(length 7.62)
+					(name "VCCO_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -40.64 0)
+					(length 7.62)
+					(name "IO_L9N_T1_DQS_AD7N_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -43.18 0)
+					(length 7.62)
+					(name "IO_L8P_T1_AD14P_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 -45.72 0)
+					(length 7.62)
+					(name "VCCO_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -48.26 0)
+					(length 7.62)
+					(name "IO_L4P_T0_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -50.8 0)
+					(length 7.62)
+					(name "IO_L2N_T0_AD12N_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -53.34 0)
+					(length 7.62)
+					(name "IO_L2P_T0_AD12P_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -55.88 0)
+					(length 7.62)
+					(name "IO_L1P_T0_AD4P_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -58.42 0)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -60.96 0)
+					(length 7.62)
+					(name "IO_L3P_T0_DQS_AD1P_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -63.5 0)
+					(length 7.62)
+					(name "IO_L4P_T0_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -66.04 0)
+					(length 7.62)
+					(name "IO_L4N_T0_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -68.58 0)
+					(length 7.62)
+					(name "IO_L5P_T0_AD9P_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 -71.12 0)
+					(length 7.62)
+					(name "VCCO_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -73.66 0)
+					(length 7.62)
+					(name "IO_L8N_T1_AD10N_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -76.2 0)
+					(length 7.62)
+					(name "IO_L9P_T1_DQS_AD3P_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -78.74 0)
+					(length 7.62)
+					(name "IO_L10N_T1_AD11N_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -81.28 0)
+					(length 7.62)
+					(name "IO_L9P_T1_DQS_AD7P_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "C1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -83.82 0)
+					(length 7.62)
+					(name "IO_L7N_T1_AD6N_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "C2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -86.36 0)
+					(length 7.62)
+					(name "IO_L7P_T1_AD6P_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "C3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -88.9 0)
+					(length 7.62)
+					(name "IO_L12N_T1_MRCC_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "C4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -91.44 0)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "C5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -93.98 0)
+					(length 7.62)
+					(name "IO_L5N_T0_AD13N_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "C6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -96.52 0)
+					(length 7.62)
+					(name "IO_L5P_T0_AD13P_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "C7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -99.06 0)
+					(length 7.62)
+					(name "IO_L1P_T0_AD0P_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "C8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -101.6 0)
+					(length 7.62)
+					(name "IO_L1N_T0_AD0N_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "C9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 -104.14 0)
+					(length 7.62)
+					(name "VCCO_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "C10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -106.68 0)
+					(length 7.62)
+					(name "IO_L11P_T1_SRCC_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "C11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 73.66 0 180)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "F6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -2.54 180)
+					(length 7.62)
+					(name "IO_L13P_T2_MRCC_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "F5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -5.08 180)
+					(length 7.62)
+					(name "IO_L14P_T2_SRCC_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "F4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -7.62 180)
+					(length 7.62)
+					(name "IO_L14N_T2_SRCC_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "F3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -10.16 180)
+					(length 7.62)
+					(name "IO_L15P_T2_DQS_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "F2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 73.66 -12.7 180)
+					(length 7.62)
+					(name "VCCO_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "F1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -15.24 180)
+					(length 7.62)
+					(name "IO_L17P_T2_A26_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "E16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -17.78 180)
+					(length 7.62)
+					(name "IO_L18N_T2_A23_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "E15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 73.66 -20.32 180)
+					(length 7.62)
+					(name "VCCO_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "E14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -22.86 180)
+					(length 7.62)
+					(name "IO_L13N_T2_MRCC_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "E13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -25.4 180)
+					(length 7.62)
+					(name "IO_L13P_T2_MRCC_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "E12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -27.94 180)
+					(length 7.62)
+					(name "IO_L14P_T2_SRCC_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "E11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 73.66 -30.48 180)
+					(length 7.62)
+					(name "VCCBRAM"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "E10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 73.66 -33.02 180)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "E9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -35.56 180)
+					(length 7.62)
+					(name "CCLK_0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "E8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at 73.66 -38.1 180)
+					(length 7.62)
+					(name "CFGBVS_0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "E7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -40.64 180)
+					(length 7.62)
+					(name "IO_0_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "E6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -43.18 180)
+					(length 7.62)
+					(name "IO_L13N_T2_MRCC_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "E5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 73.66 -45.72 180)
+					(length 7.62)
+					(name "VCCO_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "E4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -48.26 180)
+					(length 7.62)
+					(name "IO_L11P_T1_SRCC_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "E3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -50.8 180)
+					(length 7.62)
+					(name "IO_L10P_T1_AD15P_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "E2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -53.34 180)
+					(length 7.62)
+					(name "IO_L15N_T2_DQS_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "E1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -55.88 180)
+					(length 7.62)
+					(name "IO_L17N_T2_A25_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "D16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -58.42 180)
+					(length 7.62)
+					(name "IO_L15N_T2_DQS_ADV_B_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "D15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -60.96 180)
+					(length 7.62)
+					(name "IO_L15P_T2_DQS_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "D14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -63.5 180)
+					(length 7.62)
+					(name "IO_L12P_T1_MRCC_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "D13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 73.66 -66.04 180)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "D12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -68.58 180)
+					(length 7.62)
+					(name "IO_L14N_T2_SRCC_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "D11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -71.12 180)
+					(length 7.62)
+					(name "IO_0_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "D10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -73.66 180)
+					(length 7.62)
+					(name "IO_L6N_T0_VREF_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "D9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -76.2 180)
+					(length 7.62)
+					(name "IO_L6P_T0_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "D8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 73.66 -78.74 180)
+					(length 7.62)
+					(name "VCCO_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "D7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -81.28 180)
+					(length 7.62)
+					(name "IO_L6P_T0_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "D6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -83.82 180)
+					(length 7.62)
+					(name "IO_L6N_T0_VREF_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "D5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -86.36 180)
+					(length 7.62)
+					(name "IO_L12P_T1_MRCC_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "D4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -88.9 180)
+					(length 7.62)
+					(name "IO_L11N_T1_SRCC_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "D3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 73.66 -91.44 180)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "D2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -93.98 180)
+					(length 7.62)
+					(name "IO_L10N_T1_AD15N_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "D1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -96.52 180)
+					(length 7.62)
+					(name "IO_L10P_T1_AD11P_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "C16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 73.66 -99.06 180)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "C15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -101.6 180)
+					(length 7.62)
+					(name "IO_L8P_T1_AD10P_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "C14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -104.14 180)
+					(length 7.62)
+					(name "IO_L12N_T1_MRCC_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "C13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -106.68 180)
+					(length 7.62)
+					(name "IO_L11N_T1_SRCC_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "C12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(symbol "XC7A35T-1FTG256C_1_2_1"
+				(polyline
+					(pts
+						(xy 7.62 5.08) (xy 7.62 -111.76)
+					)
+					(stroke
+						(width 0.127)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 7.62 -111.76) (xy 62.23 -111.76)
+					)
+					(stroke
+						(width 0.127)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 62.23 5.08) (xy 7.62 5.08)
+					)
+					(stroke
+						(width 0.127)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 62.23 -111.76) (xy 62.23 5.08)
+					)
+					(stroke
+						(width 0.127)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(text "FPGA\nB"
+					(at 34.29 -44.45 0)
+					(effects
+						(font
+							(size 2.54 2.54)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 0 0)
+					(length 7.62)
+					(name "VCCINT"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "F7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 -2.54 0)
+					(length 7.62)
+					(name "VCCBATT_0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "F8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 -5.08 0)
+					(length 7.62)
+					(name "VCCINT"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "F9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -7.62 0)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "F10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 -10.16 0)
+					(length 7.62)
+					(name "VCCBRAM"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "F11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -12.7 0)
+					(length 7.62)
+					(name "IO_L16P_T2_A28_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "F12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -15.24 0)
+					(length 7.62)
+					(name "IO_L16N_T2_A27_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "F13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -17.78 0)
+					(length 7.62)
+					(name "IO_L21N_T3_DQS_A18_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "F14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -20.32 0)
+					(length 7.62)
+					(name "IO_L18P_T2_A24_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "F15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -22.86 0)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "F16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -25.4 0)
+					(length 7.62)
+					(name "IO_L17N_T2_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "G1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -27.94 0)
+					(length 7.62)
+					(name "IO_L17P_T2_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "G2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -30.48 0)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "G3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -33.02 0)
+					(length 7.62)
+					(name "IO_L16N_T2_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "G4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -35.56 0)
+					(length 7.62)
+					(name "IO_L16P_T2_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "G5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 -38.1 0)
+					(length 7.62)
+					(name "VCCINT"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "G6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -40.64 0)
+					(length 7.62)
+					(name "GNDADC_0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "G7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 -43.18 0)
+					(length 7.62)
+					(name "VCCADC_0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "G8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -45.72 0)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "G9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 -48.26 0)
+					(length 7.62)
+					(name "VCCAUX"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "G10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -50.8 0)
+					(length 7.62)
+					(name "IO_25_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "G11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -53.34 0)
+					(length 7.62)
+					(name "IO_L19N_T3_A21_VREF_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "G12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -55.88 0)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "G13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -58.42 0)
+					(length 7.62)
+					(name "IO_L21P_T3_DQS_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "G14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -60.96 0)
+					(length 7.62)
+					(name "IO_L24N_T3_RS0_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "G15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -63.5 0)
+					(length 7.62)
+					(name "IO_L22N_T3_A16_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "G16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -66.04 0)
+					(length 7.62)
+					(name "IO_L20N_T3_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "H1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -68.58 0)
+					(length 7.62)
+					(name "IO_L20P_T3_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "H2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -71.12 0)
+					(length 7.62)
+					(name "IO_L21N_T3_DQS_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "H3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -73.66 0)
+					(length 7.62)
+					(name "IO_L18N_T2_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "H4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -76.2 0)
+					(length 7.62)
+					(name "IO_L18P_T2_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "H5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -78.74 0)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "H6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 -81.28 0)
+					(length 7.62)
+					(name "VREFN_0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "H7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at 0 -83.82 0)
+					(length 7.62)
+					(name "VP_0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "H8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 -86.36 0)
+					(length 7.62)
+					(name "VCCINT"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "H9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -88.9 0)
+					(length 7.62)
+					(name "DONE_0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "H10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -91.44 0)
+					(length 7.62)
+					(name "IO_L19P_T3_A22_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "H11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -93.98 0)
+					(length 7.62)
+					(name "IO_L20P_T3_A20_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "H12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -96.52 0)
+					(length 7.62)
+					(name "IO_L20N_T3_A19_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "H13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -99.06 0)
+					(length 7.62)
+					(name "IO_L24P_T3_RS1_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "H14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 -101.6 0)
+					(length 7.62)
+					(name "VCCO_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "H15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -104.14 0)
+					(length 7.62)
+					(name "IO_L22P_T3_A17_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "H16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -106.68 0)
+					(length 7.62)
+					(name "IO_L22N_T3_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "J1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 62.23 0 180)
+					(length 7.62)
+					(name "IO_L6P_T0_FCS_B_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "L12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 62.23 -2.54 180)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "L11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 62.23 -5.08 180)
+					(length 7.62)
+					(name "VCCAUX"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "L10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at 62.23 -7.62 180)
+					(length 7.62)
+					(name "PROGRAM_B_0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "L9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 62.23 -10.16 180)
+					(length 7.62)
+					(name "VCCINT"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "L8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at 62.23 -12.7 180)
+					(length 7.62)
+					(name "TCK_0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "L7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 62.23 -15.24 180)
+					(length 7.62)
+					(name "VCCO_0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "L6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 62.23 -17.78 180)
+					(length 7.62)
+					(name "IO_0_34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "L5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 62.23 -20.32 180)
+					(length 7.62)
+					(name "IO_L1P_T0_34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "L4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 62.23 -22.86 180)
+					(length 7.62)
+					(name "IO_L23P_T3_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "L3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 62.23 -25.4 180)
+					(length 7.62)
+					(name "IO_L23N_T3_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "L2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 62.23 -27.94 180)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "L1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 62.23 -30.48 180)
+					(length 7.62)
+					(name "IO_L2N_T0_D03_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "K16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 62.23 -33.02 180)
+					(length 7.62)
+					(name "IO_L2P_T0_D02_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "K15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 62.23 -35.56 180)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "K14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 62.23 -38.1 180)
+					(length 7.62)
+					(name "IO_L5P_T0_D06_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "K13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 62.23 -40.64 180)
+					(length 7.62)
+					(name "IO_0_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "K12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 62.23 -43.18 180)
+					(length 7.62)
+					(name "VCCAUX"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "K11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 62.23 -45.72 180)
+					(length 7.62)
+					(name "INIT_B_0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "K10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 62.23 -48.26 180)
+					(length 7.62)
+					(name "VCCINT"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "K9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin unspecified line
+					(at 62.23 -50.8 180)
+					(length 7.62)
+					(name "DXP_0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "K8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin unspecified line
+					(at 62.23 -53.34 180)
+					(length 7.62)
+					(name "DXN_0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "K7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 62.23 -55.88 180)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "K6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 62.23 -58.42 180)
+					(length 7.62)
+					(name "IO_25_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "K5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 62.23 -60.96 180)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "K4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 62.23 -63.5 180)
+					(length 7.62)
+					(name "IO_L24P_T3_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "K3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 62.23 -66.04 180)
+					(length 7.62)
+					(name "IO_L24N_T3_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "K2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 62.23 -68.58 180)
+					(length 7.62)
+					(name "IO_L22P_T3_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "K1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 62.23 -71.12 180)
+					(length 7.62)
+					(name "IO_L23N_T3_FWE_B_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "J16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 62.23 -73.66 180)
+					(length 7.62)
+					(name "IO_L23P_T3_FOE_B_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "J15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 62.23 -76.2 180)
+					(length 7.62)
+					(name "IO_L1N_T0_D01_DIN_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "J14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 62.23 -78.74 180)
+					(length 7.62)
+					(name "IO_L1P_T0_D00_MOSI_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "J13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 62.23 -81.28 180)
+					(length 7.62)
+					(name "VCCO_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "J12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 62.23 -83.82 180)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "J11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 62.23 -86.36 180)
+					(length 7.62)
+					(name "VCCAUX"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "J10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 62.23 -88.9 180)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "J9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 62.23 -91.44 180)
+					(length 7.62)
+					(name "VREFP_0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "J8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at 62.23 -93.98 180)
+					(length 7.62)
+					(name "VN_0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "J7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 62.23 -96.52 180)
+					(length 7.62)
+					(name "VCCINT"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "J6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 62.23 -99.06 180)
+					(length 7.62)
+					(name "IO_L19P_T3_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "J5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 62.23 -101.6 180)
+					(length 7.62)
+					(name "IO_L19N_T3_VREF_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "J4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 62.23 -104.14 180)
+					(length 7.62)
+					(name "IO_L21P_T3_DQS_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "J3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 62.23 -106.68 180)
+					(length 7.62)
+					(name "VCCO_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "J2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(symbol "XC7A35T-1FTG256C_1_3_1"
+				(polyline
+					(pts
+						(xy 7.62 5.08) (xy 7.62 -111.76)
+					)
+					(stroke
+						(width 0.127)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 7.62 -111.76) (xy 83.82 -111.76)
+					)
+					(stroke
+						(width 0.127)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 83.82 5.08) (xy 7.62 5.08)
+					)
+					(stroke
+						(width 0.127)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 83.82 -111.76) (xy 83.82 5.08)
+					)
+					(stroke
+						(width 0.127)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(text "FPGA\nC"
+					(at 45.974 -46.482 0)
+					(effects
+						(font
+							(size 2.54 2.54)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 0 0)
+					(length 7.62)
+					(name "IO_L5N_T0_D07_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "L13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -2.54 0)
+					(length 7.62)
+					(name "IO_L4P_T0_D04_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "L14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -5.08 0)
+					(length 7.62)
+					(name "IO_L3P_T0_DQS_PUDC_B_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "L15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 -7.62 0)
+					(length 7.62)
+					(name "VCCO_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "L16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -10.16 0)
+					(length 7.62)
+					(name "IO_L2N_T0_34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "M1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -12.7 0)
+					(length 7.62)
+					(name "IO_L2P_T0_34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "M2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 -15.24 0)
+					(length 7.62)
+					(name "VCCO_34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "M3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -17.78 0)
+					(length 7.62)
+					(name "IO_L1N_T0_34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "M4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -20.32 0)
+					(length 7.62)
+					(name "IO_L6P_T0_34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "M5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -22.86 0)
+					(length 7.62)
+					(name "IO_L19P_T3_A10_D26_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "M6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at 0 -25.4 0)
+					(length 7.62)
+					(name "TMS_0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "M7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -27.94 0)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "M8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at 0 -30.48 0)
+					(length 7.62)
+					(name "M0_0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "M9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at 0 -33.02 0)
+					(length 7.62)
+					(name "M1_0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "M10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at 0 -35.56 0)
+					(length 7.62)
+					(name "M2_0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "M11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -38.1 0)
+					(length 7.62)
+					(name "IO_L6N_T0_D08_VREF_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "M12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 -40.64 0)
+					(length 7.62)
+					(name "VCCO_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "M13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -43.18 0)
+					(length 7.62)
+					(name "IO_L4N_T0_D05_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "M14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -45.72 0)
+					(length 7.62)
+					(name "IO_L3N_T0_DQS_EMCCLK_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "M15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -48.26 0)
+					(length 7.62)
+					(name "IO_L7P_T1_D09_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "M16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -50.8 0)
+					(length 7.62)
+					(name "IO_L4P_T0_34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "N1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -53.34 0)
+					(length 7.62)
+					(name "IO_L3N_T0_DQS_34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "N2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -55.88 0)
+					(length 7.62)
+					(name "IO_L3P_T0_DQS_34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "N3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -58.42 0)
+					(length 7.62)
+					(name "IO_L6N_T0_VREF_34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "N4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -60.96 0)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "N5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -63.5 0)
+					(length 7.62)
+					(name "IO_L19N_T3_A09_D25_VREF_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "N6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at 0 -66.04 0)
+					(length 7.62)
+					(name "TDI_0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "N7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin output line
+					(at 0 -68.58 0)
+					(length 7.62)
+					(name "TDO_0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "N8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -71.12 0)
+					(length 7.62)
+					(name "IO_L18P_T2_A12_D28_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "N9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 -73.66 0)
+					(length 7.62)
+					(name "VCCO_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "N10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -76.2 0)
+					(length 7.62)
+					(name "IO_L13P_T2_MRCC_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "N11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -78.74 0)
+					(length 7.62)
+					(name "IO_L13N_T2_MRCC_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "N12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -81.28 0)
+					(length 7.62)
+					(name "IO_L11P_T1_SRCC_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "N13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -83.82 0)
+					(length 7.62)
+					(name "IO_L12P_T1_MRCC_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "N14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -86.36 0)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "N15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -88.9 0)
+					(length 7.62)
+					(name "IO_L7N_T1_D10_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "N16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -91.44 0)
+					(length 7.62)
+					(name "IO_L4N_T0_34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "P1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -93.98 0)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "P2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -96.52 0)
+					(length 7.62)
+					(name "IO_L5N_T0_34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "P3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -99.06 0)
+					(length 7.62)
+					(name "IO_L5P_T0_34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "P4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -101.6 0)
+					(length 7.62)
+					(name "IO_L10P_T1_34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "P5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -104.14 0)
+					(length 7.62)
+					(name "IO_25_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "P6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 -106.68 0)
+					(length 7.62)
+					(name "VCCO_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "P7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 83.82 -5.08 180)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "T16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -7.62 180)
+					(length 7.62)
+					(name "IO_L10N_T1_D15_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "T15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -10.16 180)
+					(length 7.62)
+					(name "IO_L10P_T1_D14_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "T14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -12.7 180)
+					(length 7.62)
+					(name "IO_L16N_T2_A15_D31_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "T13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -15.24 180)
+					(length 7.62)
+					(name "IO_L15N_T2_DQS_DOUT_CSO_B_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "T12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 83.82 -17.78 180)
+					(length 7.62)
+					(name "VCCO_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "T11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -20.32 180)
+					(length 7.62)
+					(name "IO_L22N_T3_A04_D20_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "T10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -22.86 180)
+					(length 7.62)
+					(name "IO_L22P_T3_A05_D21_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "T9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -25.4 180)
+					(length 7.62)
+					(name "IO_L21N_T3_DQS_A06_D22_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "T8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -27.94 180)
+					(length 7.62)
+					(name "IO_L21P_T3_DQS_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "T7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 83.82 -30.48 180)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "T6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -33.02 180)
+					(length 7.62)
+					(name "IO_L23N_T3_A02_D18_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "T5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -35.56 180)
+					(length 7.62)
+					(name "IO_L9P_T1_DQS_34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "T4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -38.1 180)
+					(length 7.62)
+					(name "IO_L9N_T1_DQS_34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "T3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -40.64 180)
+					(length 7.62)
+					(name "IO_L8N_T1_34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "T2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 83.82 -43.18 180)
+					(length 7.62)
+					(name "VCCO_34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "T1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -45.72 180)
+					(length 7.62)
+					(name "IO_L9N_T1_DQS_D13_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "R16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -48.26 180)
+					(length 7.62)
+					(name "IO_L9P_T1_DQS_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "R15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 83.82 -50.8 180)
+					(length 7.62)
+					(name "VCCO_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "R14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -53.34 180)
+					(length 7.62)
+					(name "IO_L16P_T2_CSI_B_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "R13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -55.88 180)
+					(length 7.62)
+					(name "IO_L15P_T2_DQS_RDWR_B_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "R12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -58.42 180)
+					(length 7.62)
+					(name "IO_L17N_T2_A13_D29_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "R11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -60.96 180)
+					(length 7.62)
+					(name "IO_L17P_T2_A14_D30_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "R10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 83.82 -63.5 180)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "R9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -66.04 180)
+					(length 7.62)
+					(name "IO_L20N_T3_A07_D23_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "R8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -68.58 180)
+					(length 7.62)
+					(name "IO_L24N_T3_A00_D16_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "R7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -71.12 180)
+					(length 7.62)
+					(name "IO_L24P_T3_A01_D17_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "R6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -73.66 180)
+					(length 7.62)
+					(name "IO_L23P_T3_A03_D19_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "R5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 83.82 -76.2 180)
+					(length 7.62)
+					(name "VCCO_34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "R4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -78.74 180)
+					(length 7.62)
+					(name "IO_L8P_T1_34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "R3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -81.28 180)
+					(length 7.62)
+					(name "IO_L7P_T1_34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "R2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -83.82 180)
+					(length 7.62)
+					(name "IO_L7N_T1_34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "R1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -86.36 180)
+					(length 7.62)
+					(name "IO_L8N_T1_D12_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "P16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -88.9 180)
+					(length 7.62)
+					(name "IO_L8P_T1_D11_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "P15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -91.44 180)
+					(length 7.62)
+					(name "IO_L12N_T1_MRCC_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "P14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -93.98 180)
+					(length 7.62)
+					(name "IO_L11N_T1_SRCC_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "P13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 83.82 -96.52 180)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "P12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -99.06 180)
+					(length 7.62)
+					(name "IO_L14N_T2_SRCC_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "P11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -101.6 180)
+					(length 7.62)
+					(name "IO_L14P_T2_SRCC_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "P10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -104.14 180)
+					(length 7.62)
+					(name "IO_L18N_T2_A11_D27_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "P9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -106.68 180)
+					(length 7.62)
+					(name "IO_L20P_T3_A08_D24_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "P8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "XC7A35T-1FTG256C_2"
+			(pin_names
+				(offset 0.254)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "U1"
+				(at 58.42 10.16 0)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+				)
+			)
+			(property "Value" "XC7A35T-1FTG256C"
+				(at 58.42 7.62 0)
+				(effects
+					(font
+						(size 1.524 1.524)
+					)
+				)
+			)
+			(property "Footprint" "LIB_IRISHSAT:FT&slash_FTG256ARTIX-7_AMD"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+						(italic yes)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "XC7A35T-1FTG256C"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+						(italic yes)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_locked" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "XC7A35T-1FTG256C"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "FT/FTG256ARTIX-7_AMD FT/FTG256ARTIX-7_AMD-M FT/FTG256ARTIX-7_AMD-L"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "XC7A35T-1FTG256C_2_1_1"
+				(polyline
+					(pts
+						(xy 7.62 5.08) (xy 7.62 -111.76)
+					)
+					(stroke
+						(width 0.127)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 7.62 -111.76) (xy 66.04 -111.76)
+					)
+					(stroke
+						(width 0.127)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 66.04 5.08) (xy 7.62 5.08)
+					)
+					(stroke
+						(width 0.127)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 66.04 -111.76) (xy 66.04 5.08)
+					)
+					(stroke
+						(width 0.127)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(text "FPGA\nA"
+					(at 38.862 -41.91 0)
+					(effects
+						(font
+							(size 2.54 2.54)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 0 0)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -2.54 0)
+					(length 7.62)
+					(name "IO_L8N_T1_AD14N_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -5.08 0)
+					(length 7.62)
+					(name "IO_L4N_T0_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -7.62 0)
+					(length 7.62)
+					(name "IO_L3N_T0_DQS_AD5N_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -10.16 0)
+					(length 7.62)
+					(name "IO_L3P_T0_DQS_AD5P_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 -12.7 0)
+					(length 7.62)
+					(name "VCCO_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -15.24 0)
+					(length 7.62)
+					(name "IO_L1N_T0_AD4N_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -17.78 0)
+					(length 7.62)
+					(name "IO_L2P_T0_AD8P_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -20.32 0)
+					(length 7.62)
+					(name "IO_L2N_T0_AD8N_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -22.86 0)
+					(length 7.62)
+					(name "IO_L3N_T0_DQS_AD1N_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -25.4 0)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -27.94 0)
+					(length 7.62)
+					(name "IO_L5N_T0_AD9N_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -30.48 0)
+					(length 7.62)
+					(name "IO_L7P_T1_AD2P_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -33.02 0)
+					(length 7.62)
+					(name "IO_L7N_T1_AD2N_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -35.56 0)
+					(length 7.62)
+					(name "IO_L9N_T1_DQS_AD3N_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 -38.1 0)
+					(length 7.62)
+					(name "VCCO_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -40.64 0)
+					(length 7.62)
+					(name "IO_L9N_T1_DQS_AD7N_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -43.18 0)
+					(length 7.62)
+					(name "IO_L8P_T1_AD14P_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 -45.72 0)
+					(length 7.62)
+					(name "VCCO_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -48.26 0)
+					(length 7.62)
+					(name "IO_L4P_T0_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -50.8 0)
+					(length 7.62)
+					(name "IO_L2N_T0_AD12N_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -53.34 0)
+					(length 7.62)
+					(name "IO_L2P_T0_AD12P_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -55.88 0)
+					(length 7.62)
+					(name "IO_L1P_T0_AD4P_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -58.42 0)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -60.96 0)
+					(length 7.62)
+					(name "IO_L3P_T0_DQS_AD1P_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -63.5 0)
+					(length 7.62)
+					(name "IO_L4P_T0_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -66.04 0)
+					(length 7.62)
+					(name "IO_L4N_T0_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -68.58 0)
+					(length 7.62)
+					(name "IO_L5P_T0_AD9P_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 -71.12 0)
+					(length 7.62)
+					(name "VCCO_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -73.66 0)
+					(length 7.62)
+					(name "IO_L8N_T1_AD10N_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -76.2 0)
+					(length 7.62)
+					(name "IO_L9P_T1_DQS_AD3P_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -78.74 0)
+					(length 7.62)
+					(name "IO_L10N_T1_AD11N_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -81.28 0)
+					(length 7.62)
+					(name "IO_L9P_T1_DQS_AD7P_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "C1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -83.82 0)
+					(length 7.62)
+					(name "IO_L7N_T1_AD6N_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "C2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -86.36 0)
+					(length 7.62)
+					(name "IO_L7P_T1_AD6P_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "C3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -88.9 0)
+					(length 7.62)
+					(name "IO_L12N_T1_MRCC_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "C4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -91.44 0)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "C5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -93.98 0)
+					(length 7.62)
+					(name "IO_L5N_T0_AD13N_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "C6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -96.52 0)
+					(length 7.62)
+					(name "IO_L5P_T0_AD13P_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "C7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -99.06 0)
+					(length 7.62)
+					(name "IO_L1P_T0_AD0P_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "C8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -101.6 0)
+					(length 7.62)
+					(name "IO_L1N_T0_AD0N_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "C9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 -104.14 0)
+					(length 7.62)
+					(name "VCCO_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "C10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -106.68 0)
+					(length 7.62)
+					(name "IO_L11P_T1_SRCC_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "C11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 73.66 0 180)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "F6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -2.54 180)
+					(length 7.62)
+					(name "IO_L13P_T2_MRCC_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "F5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -5.08 180)
+					(length 7.62)
+					(name "IO_L14P_T2_SRCC_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "F4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -7.62 180)
+					(length 7.62)
+					(name "IO_L14N_T2_SRCC_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "F3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -10.16 180)
+					(length 7.62)
+					(name "IO_L15P_T2_DQS_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "F2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 73.66 -12.7 180)
+					(length 7.62)
+					(name "VCCO_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "F1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -15.24 180)
+					(length 7.62)
+					(name "IO_L17P_T2_A26_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "E16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -17.78 180)
+					(length 7.62)
+					(name "IO_L18N_T2_A23_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "E15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 73.66 -20.32 180)
+					(length 7.62)
+					(name "VCCO_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "E14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -22.86 180)
+					(length 7.62)
+					(name "IO_L13N_T2_MRCC_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "E13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -25.4 180)
+					(length 7.62)
+					(name "IO_L13P_T2_MRCC_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "E12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -27.94 180)
+					(length 7.62)
+					(name "IO_L14P_T2_SRCC_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "E11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 73.66 -30.48 180)
+					(length 7.62)
+					(name "VCCBRAM"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "E10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 73.66 -33.02 180)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "E9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -35.56 180)
+					(length 7.62)
+					(name "CCLK_0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "E8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at 73.66 -38.1 180)
+					(length 7.62)
+					(name "CFGBVS_0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "E7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -40.64 180)
+					(length 7.62)
+					(name "IO_0_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "E6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -43.18 180)
+					(length 7.62)
+					(name "IO_L13N_T2_MRCC_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "E5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 73.66 -45.72 180)
+					(length 7.62)
+					(name "VCCO_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "E4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -48.26 180)
+					(length 7.62)
+					(name "IO_L11P_T1_SRCC_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "E3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -50.8 180)
+					(length 7.62)
+					(name "IO_L10P_T1_AD15P_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "E2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -53.34 180)
+					(length 7.62)
+					(name "IO_L15N_T2_DQS_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "E1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -55.88 180)
+					(length 7.62)
+					(name "IO_L17N_T2_A25_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "D16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -58.42 180)
+					(length 7.62)
+					(name "IO_L15N_T2_DQS_ADV_B_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "D15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -60.96 180)
+					(length 7.62)
+					(name "IO_L15P_T2_DQS_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "D14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -63.5 180)
+					(length 7.62)
+					(name "IO_L12P_T1_MRCC_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "D13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 73.66 -66.04 180)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "D12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -68.58 180)
+					(length 7.62)
+					(name "IO_L14N_T2_SRCC_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "D11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -71.12 180)
+					(length 7.62)
+					(name "IO_0_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "D10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -73.66 180)
+					(length 7.62)
+					(name "IO_L6N_T0_VREF_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "D9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -76.2 180)
+					(length 7.62)
+					(name "IO_L6P_T0_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "D8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 73.66 -78.74 180)
+					(length 7.62)
+					(name "VCCO_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "D7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -81.28 180)
+					(length 7.62)
+					(name "IO_L6P_T0_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "D6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -83.82 180)
+					(length 7.62)
+					(name "IO_L6N_T0_VREF_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "D5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -86.36 180)
+					(length 7.62)
+					(name "IO_L12P_T1_MRCC_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "D4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -88.9 180)
+					(length 7.62)
+					(name "IO_L11N_T1_SRCC_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "D3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 73.66 -91.44 180)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "D2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -93.98 180)
+					(length 7.62)
+					(name "IO_L10N_T1_AD15N_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "D1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -96.52 180)
+					(length 7.62)
+					(name "IO_L10P_T1_AD11P_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "C16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 73.66 -99.06 180)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "C15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -101.6 180)
+					(length 7.62)
+					(name "IO_L8P_T1_AD10P_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "C14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -104.14 180)
+					(length 7.62)
+					(name "IO_L12N_T1_MRCC_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "C13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 73.66 -106.68 180)
+					(length 7.62)
+					(name "IO_L11N_T1_SRCC_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "C12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(symbol "XC7A35T-1FTG256C_2_2_1"
+				(polyline
+					(pts
+						(xy 7.62 5.08) (xy 7.62 -111.76)
+					)
+					(stroke
+						(width 0.127)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 7.62 -111.76) (xy 62.23 -111.76)
+					)
+					(stroke
+						(width 0.127)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 62.23 5.08) (xy 7.62 5.08)
+					)
+					(stroke
+						(width 0.127)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 62.23 -111.76) (xy 62.23 5.08)
+					)
+					(stroke
+						(width 0.127)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(text "FPGA\nB"
+					(at 34.29 -44.45 0)
+					(effects
+						(font
+							(size 2.54 2.54)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 0 0)
+					(length 7.62)
+					(name "VCCINT"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "F7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 -2.54 0)
+					(length 7.62)
+					(name "VCCBATT_0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "F8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 -5.08 0)
+					(length 7.62)
+					(name "VCCINT"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "F9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -7.62 0)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "F10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 -10.16 0)
+					(length 7.62)
+					(name "VCCBRAM"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "F11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -12.7 0)
+					(length 7.62)
+					(name "IO_L16P_T2_A28_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "F12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -15.24 0)
+					(length 7.62)
+					(name "IO_L16N_T2_A27_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "F13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -17.78 0)
+					(length 7.62)
+					(name "IO_L21N_T3_DQS_A18_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "F14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -20.32 0)
+					(length 7.62)
+					(name "IO_L18P_T2_A24_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "F15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -22.86 0)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "F16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -25.4 0)
+					(length 7.62)
+					(name "IO_L17N_T2_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "G1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -27.94 0)
+					(length 7.62)
+					(name "IO_L17P_T2_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "G2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -30.48 0)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "G3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -33.02 0)
+					(length 7.62)
+					(name "IO_L16N_T2_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "G4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -35.56 0)
+					(length 7.62)
+					(name "IO_L16P_T2_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "G5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 -38.1 0)
+					(length 7.62)
+					(name "VCCINT"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "G6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -40.64 0)
+					(length 7.62)
+					(name "GNDADC_0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "G7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 -43.18 0)
+					(length 7.62)
+					(name "VCCADC_0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "G8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -45.72 0)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "G9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 -48.26 0)
+					(length 7.62)
+					(name "VCCAUX"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "G10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -50.8 0)
+					(length 7.62)
+					(name "IO_25_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "G11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -53.34 0)
+					(length 7.62)
+					(name "IO_L19N_T3_A21_VREF_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "G12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -55.88 0)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "G13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -58.42 0)
+					(length 7.62)
+					(name "IO_L21P_T3_DQS_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "G14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -60.96 0)
+					(length 7.62)
+					(name "IO_L24N_T3_RS0_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "G15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -63.5 0)
+					(length 7.62)
+					(name "IO_L22N_T3_A16_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "G16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -66.04 0)
+					(length 7.62)
+					(name "IO_L20N_T3_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "H1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -68.58 0)
+					(length 7.62)
+					(name "IO_L20P_T3_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "H2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -71.12 0)
+					(length 7.62)
+					(name "IO_L21N_T3_DQS_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "H3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -73.66 0)
+					(length 7.62)
+					(name "IO_L18N_T2_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "H4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -76.2 0)
+					(length 7.62)
+					(name "IO_L18P_T2_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "H5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -78.74 0)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "H6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 -81.28 0)
+					(length 7.62)
+					(name "VREFN_0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "H7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at 0 -83.82 0)
+					(length 7.62)
+					(name "VP_0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "H8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 -86.36 0)
+					(length 7.62)
+					(name "VCCINT"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "H9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -88.9 0)
+					(length 7.62)
+					(name "DONE_0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "H10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -91.44 0)
+					(length 7.62)
+					(name "IO_L19P_T3_A22_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "H11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -93.98 0)
+					(length 7.62)
+					(name "IO_L20P_T3_A20_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "H12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -96.52 0)
+					(length 7.62)
+					(name "IO_L20N_T3_A19_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "H13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -99.06 0)
+					(length 7.62)
+					(name "IO_L24P_T3_RS1_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "H14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 -101.6 0)
+					(length 7.62)
+					(name "VCCO_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "H15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -104.14 0)
+					(length 7.62)
+					(name "IO_L22P_T3_A17_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "H16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -106.68 0)
+					(length 7.62)
+					(name "IO_L22N_T3_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "J1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 62.23 0 180)
+					(length 7.62)
+					(name "IO_L6P_T0_FCS_B_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "L12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 62.23 -2.54 180)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "L11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 62.23 -5.08 180)
+					(length 7.62)
+					(name "VCCAUX"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "L10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at 62.23 -7.62 180)
+					(length 7.62)
+					(name "PROGRAM_B_0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "L9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 62.23 -10.16 180)
+					(length 7.62)
+					(name "VCCINT"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "L8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at 62.23 -12.7 180)
+					(length 7.62)
+					(name "TCK_0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "L7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 62.23 -15.24 180)
+					(length 7.62)
+					(name "VCCO_0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "L6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 62.23 -17.78 180)
+					(length 7.62)
+					(name "IO_0_34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "L5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 62.23 -20.32 180)
+					(length 7.62)
+					(name "IO_L1P_T0_34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "L4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 62.23 -22.86 180)
+					(length 7.62)
+					(name "IO_L23P_T3_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "L3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 62.23 -25.4 180)
+					(length 7.62)
+					(name "IO_L23N_T3_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "L2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 62.23 -27.94 180)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "L1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 62.23 -30.48 180)
+					(length 7.62)
+					(name "IO_L2N_T0_D03_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "K16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 62.23 -33.02 180)
+					(length 7.62)
+					(name "IO_L2P_T0_D02_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "K15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 62.23 -35.56 180)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "K14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 62.23 -38.1 180)
+					(length 7.62)
+					(name "IO_L5P_T0_D06_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "K13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 62.23 -40.64 180)
+					(length 7.62)
+					(name "IO_0_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "K12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 62.23 -43.18 180)
+					(length 7.62)
+					(name "VCCAUX"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "K11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 62.23 -45.72 180)
+					(length 7.62)
+					(name "INIT_B_0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "K10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 62.23 -48.26 180)
+					(length 7.62)
+					(name "VCCINT"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "K9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin unspecified line
+					(at 62.23 -50.8 180)
+					(length 7.62)
+					(name "DXP_0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "K8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin unspecified line
+					(at 62.23 -53.34 180)
+					(length 7.62)
+					(name "DXN_0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "K7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 62.23 -55.88 180)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "K6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 62.23 -58.42 180)
+					(length 7.62)
+					(name "IO_25_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "K5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 62.23 -60.96 180)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "K4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 62.23 -63.5 180)
+					(length 7.62)
+					(name "IO_L24P_T3_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "K3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 62.23 -66.04 180)
+					(length 7.62)
+					(name "IO_L24N_T3_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "K2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 62.23 -68.58 180)
+					(length 7.62)
+					(name "IO_L22P_T3_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "K1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 62.23 -71.12 180)
+					(length 7.62)
+					(name "IO_L23N_T3_FWE_B_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "J16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 62.23 -73.66 180)
+					(length 7.62)
+					(name "IO_L23P_T3_FOE_B_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "J15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 62.23 -76.2 180)
+					(length 7.62)
+					(name "IO_L1N_T0_D01_DIN_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "J14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 62.23 -78.74 180)
+					(length 7.62)
+					(name "IO_L1P_T0_D00_MOSI_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "J13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 62.23 -81.28 180)
+					(length 7.62)
+					(name "VCCO_15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "J12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 62.23 -83.82 180)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "J11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 62.23 -86.36 180)
+					(length 7.62)
+					(name "VCCAUX"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "J10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 62.23 -88.9 180)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "J9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 62.23 -91.44 180)
+					(length 7.62)
+					(name "VREFP_0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "J8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at 62.23 -93.98 180)
+					(length 7.62)
+					(name "VN_0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "J7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 62.23 -96.52 180)
+					(length 7.62)
+					(name "VCCINT"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "J6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 62.23 -99.06 180)
+					(length 7.62)
+					(name "IO_L19P_T3_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "J5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 62.23 -101.6 180)
+					(length 7.62)
+					(name "IO_L19N_T3_VREF_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "J4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 62.23 -104.14 180)
+					(length 7.62)
+					(name "IO_L21P_T3_DQS_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "J3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 62.23 -106.68 180)
+					(length 7.62)
+					(name "VCCO_35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "J2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(symbol "XC7A35T-1FTG256C_2_3_1"
+				(polyline
+					(pts
+						(xy 7.62 5.08) (xy 7.62 -111.76)
+					)
+					(stroke
+						(width 0.127)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 7.62 -111.76) (xy 83.82 -111.76)
+					)
+					(stroke
+						(width 0.127)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 83.82 5.08) (xy 7.62 5.08)
+					)
+					(stroke
+						(width 0.127)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 83.82 -111.76) (xy 83.82 5.08)
+					)
+					(stroke
+						(width 0.127)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(text "FPGA\nC"
+					(at 45.974 -46.482 0)
+					(effects
+						(font
+							(size 2.54 2.54)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 0 0)
+					(length 7.62)
+					(name "IO_L5N_T0_D07_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "L13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -2.54 0)
+					(length 7.62)
+					(name "IO_L4P_T0_D04_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "L14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -5.08 0)
+					(length 7.62)
+					(name "IO_L3P_T0_DQS_PUDC_B_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "L15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 -7.62 0)
+					(length 7.62)
+					(name "VCCO_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "L16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -10.16 0)
+					(length 7.62)
+					(name "IO_L2N_T0_34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "M1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -12.7 0)
+					(length 7.62)
+					(name "IO_L2P_T0_34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "M2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 -15.24 0)
+					(length 7.62)
+					(name "VCCO_34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "M3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -17.78 0)
+					(length 7.62)
+					(name "IO_L1N_T0_34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "M4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -20.32 0)
+					(length 7.62)
+					(name "IO_L6P_T0_34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "M5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -22.86 0)
+					(length 7.62)
+					(name "IO_L19P_T3_A10_D26_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "M6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at 0 -25.4 0)
+					(length 7.62)
+					(name "TMS_0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "M7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -27.94 0)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "M8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at 0 -30.48 0)
+					(length 7.62)
+					(name "M0_0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "M9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at 0 -33.02 0)
+					(length 7.62)
+					(name "M1_0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "M10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at 0 -35.56 0)
+					(length 7.62)
+					(name "M2_0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "M11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -38.1 0)
+					(length 7.62)
+					(name "IO_L6N_T0_D08_VREF_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "M12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 -40.64 0)
+					(length 7.62)
+					(name "VCCO_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "M13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -43.18 0)
+					(length 7.62)
+					(name "IO_L4N_T0_D05_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "M14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -45.72 0)
+					(length 7.62)
+					(name "IO_L3N_T0_DQS_EMCCLK_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "M15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -48.26 0)
+					(length 7.62)
+					(name "IO_L7P_T1_D09_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "M16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -50.8 0)
+					(length 7.62)
+					(name "IO_L4P_T0_34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "N1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -53.34 0)
+					(length 7.62)
+					(name "IO_L3N_T0_DQS_34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "N2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -55.88 0)
+					(length 7.62)
+					(name "IO_L3P_T0_DQS_34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "N3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -58.42 0)
+					(length 7.62)
+					(name "IO_L6N_T0_VREF_34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "N4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -60.96 0)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "N5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -63.5 0)
+					(length 7.62)
+					(name "IO_L19N_T3_A09_D25_VREF_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "N6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at 0 -66.04 0)
+					(length 7.62)
+					(name "TDI_0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "N7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin output line
+					(at 0 -68.58 0)
+					(length 7.62)
+					(name "TDO_0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "N8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -71.12 0)
+					(length 7.62)
+					(name "IO_L18P_T2_A12_D28_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "N9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 -73.66 0)
+					(length 7.62)
+					(name "VCCO_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "N10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -76.2 0)
+					(length 7.62)
+					(name "IO_L13P_T2_MRCC_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "N11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -78.74 0)
+					(length 7.62)
+					(name "IO_L13N_T2_MRCC_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "N12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -81.28 0)
+					(length 7.62)
+					(name "IO_L11P_T1_SRCC_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "N13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -83.82 0)
+					(length 7.62)
+					(name "IO_L12P_T1_MRCC_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "N14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -86.36 0)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "N15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -88.9 0)
+					(length 7.62)
+					(name "IO_L7N_T1_D10_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "N16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -91.44 0)
+					(length 7.62)
+					(name "IO_L4N_T0_34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "P1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -93.98 0)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "P2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -96.52 0)
+					(length 7.62)
+					(name "IO_L5N_T0_34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "P3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -99.06 0)
+					(length 7.62)
+					(name "IO_L5P_T0_34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "P4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -101.6 0)
+					(length 7.62)
+					(name "IO_L10P_T1_34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "P5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 0 -104.14 0)
+					(length 7.62)
+					(name "IO_25_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "P6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 -106.68 0)
+					(length 7.62)
+					(name "VCCO_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "P7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 83.82 -5.08 180)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "T16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -7.62 180)
+					(length 7.62)
+					(name "IO_L10N_T1_D15_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "T15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -10.16 180)
+					(length 7.62)
+					(name "IO_L10P_T1_D14_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "T14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -12.7 180)
+					(length 7.62)
+					(name "IO_L16N_T2_A15_D31_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "T13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -15.24 180)
+					(length 7.62)
+					(name "IO_L15N_T2_DQS_DOUT_CSO_B_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "T12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 83.82 -17.78 180)
+					(length 7.62)
+					(name "VCCO_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "T11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -20.32 180)
+					(length 7.62)
+					(name "IO_L22N_T3_A04_D20_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "T10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -22.86 180)
+					(length 7.62)
+					(name "IO_L22P_T3_A05_D21_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "T9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -25.4 180)
+					(length 7.62)
+					(name "IO_L21N_T3_DQS_A06_D22_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "T8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -27.94 180)
+					(length 7.62)
+					(name "IO_L21P_T3_DQS_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "T7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 83.82 -30.48 180)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "T6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -33.02 180)
+					(length 7.62)
+					(name "IO_L23N_T3_A02_D18_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "T5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -35.56 180)
+					(length 7.62)
+					(name "IO_L9P_T1_DQS_34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "T4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -38.1 180)
+					(length 7.62)
+					(name "IO_L9N_T1_DQS_34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "T3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -40.64 180)
+					(length 7.62)
+					(name "IO_L8N_T1_34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "T2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 83.82 -43.18 180)
+					(length 7.62)
+					(name "VCCO_34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "T1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -45.72 180)
+					(length 7.62)
+					(name "IO_L9N_T1_DQS_D13_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "R16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -48.26 180)
+					(length 7.62)
+					(name "IO_L9P_T1_DQS_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "R15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 83.82 -50.8 180)
+					(length 7.62)
+					(name "VCCO_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "R14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -53.34 180)
+					(length 7.62)
+					(name "IO_L16P_T2_CSI_B_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "R13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -55.88 180)
+					(length 7.62)
+					(name "IO_L15P_T2_DQS_RDWR_B_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "R12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -58.42 180)
+					(length 7.62)
+					(name "IO_L17N_T2_A13_D29_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "R11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -60.96 180)
+					(length 7.62)
+					(name "IO_L17P_T2_A14_D30_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "R10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 83.82 -63.5 180)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "R9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -66.04 180)
+					(length 7.62)
+					(name "IO_L20N_T3_A07_D23_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "R8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -68.58 180)
+					(length 7.62)
+					(name "IO_L24N_T3_A00_D16_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "R7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -71.12 180)
+					(length 7.62)
+					(name "IO_L24P_T3_A01_D17_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "R6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -73.66 180)
+					(length 7.62)
+					(name "IO_L23P_T3_A03_D19_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "R5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 83.82 -76.2 180)
+					(length 7.62)
+					(name "VCCO_34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "R4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -78.74 180)
+					(length 7.62)
+					(name "IO_L8P_T1_34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "R3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -81.28 180)
+					(length 7.62)
+					(name "IO_L7P_T1_34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "R2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -83.82 180)
+					(length 7.62)
+					(name "IO_L7N_T1_34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "R1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -86.36 180)
+					(length 7.62)
+					(name "IO_L8N_T1_D12_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "P16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -88.9 180)
+					(length 7.62)
+					(name "IO_L8P_T1_D11_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "P15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -91.44 180)
+					(length 7.62)
+					(name "IO_L12N_T1_MRCC_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "P14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -93.98 180)
+					(length 7.62)
+					(name "IO_L11N_T1_SRCC_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "P13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 83.82 -96.52 180)
+					(length 7.62)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "P12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -99.06 180)
+					(length 7.62)
+					(name "IO_L14N_T2_SRCC_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "P11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -101.6 180)
+					(length 7.62)
+					(name "IO_L14P_T2_SRCC_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "P10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -104.14 180)
+					(length 7.62)
+					(name "IO_L18N_T2_A11_D27_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "P9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 83.82 -106.68 180)
+					(length 7.62)
+					(name "IO_L20P_T3_A08_D24_14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "P8"
 						(effects
 							(font
 								(size 1.27 1.27)
@@ -18810,7 +29316,7 @@
 	)
 	(text "2xLO Frequency"
 		(exclude_from_sim no)
-		(at 604.012 423.418 0)
+		(at 723.392 411.988 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -18820,7 +29326,7 @@
 	)
 	(text "Pin4 -> REFOUT\nindicates 2s\ncomplement and\n2Vpp"
 		(exclude_from_sim no)
-		(at 458.724 362.458 0)
+		(at 416.814 387.858 0)
 		(effects
 			(font
 				(size 1.016 1.016)
@@ -18860,7 +29366,7 @@
 	)
 	(text "Pin 29 <- Oscillator\nCan it use the 100MHz?\n"
 		(exclude_from_sim no)
-		(at 678.18 203.962 0)
+		(at 750.57 203.962 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -18870,7 +29376,7 @@
 	)
 	(text "power bypass \ncapacitors must be \nelectrically as \nclose as possible"
 		(exclude_from_sim no)
-		(at 603.504 413.766 0)
+		(at 722.884 402.336 0)
 		(effects
 			(font
 				(size 1.016 1.016)
@@ -18900,7 +29406,7 @@
 	)
 	(text "1.9 MHz LPF MOD OUTPUT TO ADC"
 		(exclude_from_sim no)
-		(at 565.15 336.296 0)
+		(at 518.16 393.446 0)
 		(effects
 			(font
 				(size 2.54 2.54)
@@ -18921,7 +29427,7 @@
 	)
 	(text "Decoupling capacitors\nplace as close to pin as possible "
 		(exclude_from_sim no)
-		(at 686.562 211.836 0)
+		(at 758.952 211.836 0)
 		(effects
 			(font
 				(size 0.762 0.762)
@@ -18961,7 +29467,7 @@
 	)
 	(text "3rd harmonic filter, LO output to demodulator"
 		(exclude_from_sim no)
-		(at 841.502 322.58 0)
+		(at 738.632 322.58 0)
 		(effects
 			(font
 				(size 1.778 1.778)
@@ -18982,7 +29488,7 @@
 	)
 	(text "Ask Chisum about ENC pins for ADC and CLK pins for DAC"
 		(exclude_from_sim no)
-		(at 453.644 436.118 0)
+		(at 420.624 676.148 0)
 		(effects
 			(font
 				(size 1.778 1.778)
@@ -19002,7 +29508,7 @@
 	)
 	(text "Disable pin able to be left\nfloating due to internal\npull up network"
 		(exclude_from_sim no)
-		(at 677.672 354.584 0)
+		(at 607.822 409.194 0)
 		(effects
 			(font
 				(size 1.016 1.016)
@@ -19042,7 +29548,7 @@
 	)
 	(text "Decoupling capacitors\nplace as close to pin as possible "
 		(exclude_from_sim no)
-		(at 689.356 256.032 0)
+		(at 761.746 256.032 0)
 		(effects
 			(font
 				(size 0.762 0.762)
@@ -19072,7 +29578,7 @@
 	)
 	(text "Connect pins to bank 14"
 		(exclude_from_sim no)
-		(at 426.974 390.906 0)
+		(at 385.064 416.306 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -19132,7 +29638,7 @@
 	)
 	(text "Suuuuuuure suuuuuuure"
 		(exclude_from_sim no)
-		(at 543.814 271.526 0)
+		(at 550.418 298.45 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -19173,7 +29679,7 @@
 	)
 	(text "PLL Filter between LO pin 7 and 20"
 		(exclude_from_sim no)
-		(at 553.212 183.134 0)
+		(at 611.632 200.914 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -19193,7 +29699,7 @@
 	)
 	(text "hi my name is thomas heehee\n"
 		(exclude_from_sim no)
-		(at 540.512 267.208 0)
+		(at 547.116 294.132 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -19223,7 +29729,7 @@
 	)
 	(text "Decoupling capacitors\nplace as close to pin as possible "
 		(exclude_from_sim no)
-		(at 699.008 228.854 0)
+		(at 771.398 228.854 0)
 		(effects
 			(font
 				(size 0.762 0.762)
@@ -19262,7 +29768,7 @@
 		(uuid "f4b39541-60f7-4035-8579-f42d1b6d7e39")
 	)
 	(junction
-		(at 1080.77 317.5)
+		(at 1012.19 368.3)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "000503ea-a910-46db-a844-309d4cccb03b")
@@ -19286,7 +29792,7 @@
 		(uuid "061d1a8c-9ee4-4179-b54d-e61ac07932db")
 	)
 	(junction
-		(at 511.81 370.84)
+		(at 469.9 396.24)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "06da2f53-cb33-4ea9-a2c9-d3e534f8238f")
@@ -19346,7 +29852,7 @@
 		(uuid "12fb35a0-6eee-49c7-8d20-83db20650a01")
 	)
 	(junction
-		(at 551.18 407.67)
+		(at 670.56 396.24)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "138e78f9-b86d-4bad-84b7-d6c54e44f8e1")
@@ -19376,7 +29882,7 @@
 		(uuid "1932b2d7-3402-4dda-88ad-4a18572dbba3")
 	)
 	(junction
-		(at 509.27 370.84)
+		(at 467.36 396.24)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "1932b9a0-0b81-4186-839c-8c11da7a5507")
@@ -19400,13 +29906,13 @@
 		(uuid "1b191902-d001-48e9-8f12-a013734b05b7")
 	)
 	(junction
-		(at 778.51 347.98)
+		(at 675.64 347.98)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "1ba98ce3-5ba3-469d-991e-f91dd915c18c")
 	)
 	(junction
-		(at 789.94 337.82)
+		(at 687.07 337.82)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "1bc60813-8f6a-4a84-aefb-976e19972877")
@@ -19448,19 +29954,19 @@
 		(uuid "2491463d-af9a-4071-ba1b-3d1f0a95b0c5")
 	)
 	(junction
-		(at 643.89 170.18)
+		(at 716.28 170.18)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "24b5ec1a-72c4-4a13-be0a-0e15d76ba13e")
 	)
 	(junction
-		(at 657.86 414.02)
+		(at 777.24 402.59)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "25896545-d231-4951-ad46-bdc8cc36b45f")
 	)
 	(junction
-		(at 541.02 328.93)
+		(at 494.03 386.08)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "25ab678b-f843-479b-a80b-2ec11236f0d6")
@@ -19514,19 +30020,19 @@
 		(uuid "29d383c9-574f-47cf-b3f4-a5956fe34337")
 	)
 	(junction
-		(at 511.81 222.25)
+		(at 609.6 256.54)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "2af1e263-b4c0-4604-b759-f522d6a3657b")
 	)
 	(junction
-		(at 659.13 251.46)
+		(at 731.52 251.46)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "2bb387f4-999d-49a9-a2a7-ef6f9b0048da")
 	)
 	(junction
-		(at 781.05 316.23)
+		(at 678.18 316.23)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "2bcdc05a-eef5-4d69-bf38-8c12d516dcd5")
@@ -19538,7 +30044,7 @@
 		(uuid "2d0be677-41fe-4a2f-915e-88ad52ffd51a")
 	)
 	(junction
-		(at 678.18 265.43)
+		(at 750.57 265.43)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "2d3b67e8-7257-4521-ae0b-2b522128bd27")
@@ -19568,7 +30074,7 @@
 		(uuid "315f1f67-4cb5-46f0-bf41-254d0e6995cb")
 	)
 	(junction
-		(at 778.51 312.42)
+		(at 675.64 312.42)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "3195b258-1ea7-4ca1-bd78-3d58f4f883bf")
@@ -19580,13 +30086,13 @@
 		(uuid "32a617bd-f8ec-4069-9a49-6d5cf238723e")
 	)
 	(junction
-		(at 425.45 346.71)
+		(at 383.54 372.11)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "3420f450-803f-4c90-92e3-0dc1bb5c6145")
 	)
 	(junction
-		(at 598.17 246.38)
+		(at 670.56 246.38)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "350df4f9-14ab-4e4f-864a-50e3c6ac1e19")
@@ -19604,7 +30110,7 @@
 		(uuid "3630ae49-70f3-4322-a308-fb4eff92f7ec")
 	)
 	(junction
-		(at 576.58 316.23)
+		(at 529.59 373.38)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "36442d1f-179b-41b4-9ecb-c0c06d957a41")
@@ -19652,6 +30158,12 @@
 		(uuid "3bb2398e-c602-4baf-984b-4cbe5a258747")
 	)
 	(junction
+		(at 642.62 402.59)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "3c614105-e5cb-426a-80d2-89bc9a8a4af7")
+	)
+	(junction
 		(at 129.54 361.95)
 		(diameter 0)
 		(color 0 0 0 0)
@@ -19664,13 +30176,13 @@
 		(uuid "3e9cedd5-a6f6-4c80-9047-a8f1ebed857a")
 	)
 	(junction
-		(at 1155.7 342.9)
+		(at 1087.12 393.7)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "3f29577a-451f-4df2-bb77-099f861c9bad")
 	)
 	(junction
-		(at 541.02 316.23)
+		(at 494.03 373.38)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "40b94cdb-bc23-4b8d-9af2-b0a6b1ace770")
@@ -19688,19 +30200,19 @@
 		(uuid "44c43916-8163-46a1-87f9-7b2ab4782635")
 	)
 	(junction
-		(at 541.02 354.33)
+		(at 494.03 411.48)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "44f3b8f3-b52b-4ccd-99b7-988ae88c7d2d")
 	)
 	(junction
-		(at 581.66 415.29)
+		(at 701.04 403.86)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "45226c34-da6e-422f-9550-089f5f8a8cbb")
 	)
 	(junction
-		(at 539.75 191.77)
+		(at 598.17 209.55)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "46eaa35c-d9c4-4efc-836d-c23e181a8002")
@@ -19712,7 +30224,7 @@
 		(uuid "46f978db-1993-4b0d-8639-4db17ff52f5c")
 	)
 	(junction
-		(at 576.58 328.93)
+		(at 529.59 386.08)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "47b27045-8df2-4a3c-acd9-762c01aa73e1")
@@ -19748,25 +30260,25 @@
 		(uuid "4b49c23f-bda7-4ad3-b364-31601fc4e108")
 	)
 	(junction
-		(at 551.18 208.28)
+		(at 609.6 226.06)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "4bdbb5ee-e98a-4717-8628-5ae7249c1a43")
 	)
 	(junction
-		(at 514.35 233.68)
+		(at 612.14 267.97)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "4c2a5b01-8d49-42ed-8b17-2143222738aa")
 	)
 	(junction
-		(at 678.18 257.81)
+		(at 750.57 257.81)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "4c7829d4-587f-4522-86db-135904d3fd6e")
 	)
 	(junction
-		(at 674.37 220.98)
+		(at 746.76 220.98)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "4c971bd0-cb7a-4a5c-960a-ee85d6e73e00")
@@ -19784,25 +30296,25 @@
 		(uuid "4dddba53-c15e-48f3-a13a-61456bc52ce9")
 	)
 	(junction
-		(at 563.88 316.23)
+		(at 516.89 373.38)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "4e6edcf1-bbdb-44cb-b36d-f13353bf9a9d")
 	)
 	(junction
-		(at 1158.24 342.9)
+		(at 1089.66 393.7)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "4e977600-24c4-4d30-9d83-a3cb66b26841")
 	)
 	(junction
-		(at 434.34 403.86)
+		(at 392.43 429.26)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "4f81d200-4645-41a7-bf86-6bf41162d9ce")
 	)
 	(junction
-		(at 449.58 328.93)
+		(at 407.67 354.33)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "502961c2-caea-477f-8c14-8a1da5b37420")
@@ -19844,7 +30356,7 @@
 		(uuid "5361635e-6bb2-488f-b18b-16e514b2b64f")
 	)
 	(junction
-		(at 624.84 407.67)
+		(at 744.22 396.24)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "5374d6c1-cd28-4271-84c1-36ad6b3ae70c")
@@ -19874,7 +30386,7 @@
 		(uuid "55db8fdd-ba70-49d5-be16-d41d8ee9ad48")
 	)
 	(junction
-		(at 624.84 392.43)
+		(at 744.22 381)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "56337b76-ccce-47f9-819c-713d65f66fce")
@@ -19898,7 +30410,7 @@
 		(uuid "5ac9fc0f-b2cb-4f02-a119-d04819e6b5c8")
 	)
 	(junction
-		(at 416.56 363.22)
+		(at 374.65 388.62)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "5b056a1e-d616-4c84-8239-a2653cb4ebbb")
@@ -19946,7 +30458,7 @@
 		(uuid "63f360ce-91de-4252-9ae9-6efd5e04fc2d")
 	)
 	(junction
-		(at 1160.78 342.9)
+		(at 1092.2 393.7)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "64c453d4-f224-4fea-9e22-0ae5ff0ced4e")
@@ -19964,7 +30476,7 @@
 		(uuid "65fdaee9-47e8-4f24-8c1c-941a62ae0061")
 	)
 	(junction
-		(at 551.18 316.23)
+		(at 504.19 373.38)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "664528c9-c584-442b-8096-d1a1e0f6fd9c")
@@ -19982,10 +30494,16 @@
 		(uuid "67253119-f9a7-44d5-880c-b1d1f156de83")
 	)
 	(junction
-		(at 563.88 328.93)
+		(at 516.89 386.08)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "685e532f-b809-49bd-95fd-2797b0f7d871")
+	)
+	(junction
+		(at 566.42 397.51)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "68ebc046-8a00-4fa8-adfb-8c74e2d88fbd")
 	)
 	(junction
 		(at 839.47 626.11)
@@ -19994,7 +30512,7 @@
 		(uuid "6981be64-9bff-4503-8ee5-264c406d76cc")
 	)
 	(junction
-		(at 688.34 238.76)
+		(at 760.73 238.76)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "6b2f696a-fe7d-49da-89f8-754e34f430ba")
@@ -20036,7 +30554,7 @@
 		(uuid "7007f0c8-7ce4-4c59-8739-06707705e232")
 	)
 	(junction
-		(at 482.6 370.84)
+		(at 440.69 396.24)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "70e2bfce-c950-4ced-ad87-b5fb4b3a0fc1")
@@ -20060,7 +30578,7 @@
 		(uuid "724d6f96-cf7d-4202-b297-25f15c1e1aeb")
 	)
 	(junction
-		(at 814.07 337.82)
+		(at 711.2 337.82)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "72b132ef-c714-4543-b8a5-0beffe6f0918")
@@ -20072,7 +30590,7 @@
 		(uuid "733c0625-972a-4b63-a855-72302ef37049")
 	)
 	(junction
-		(at 781.05 337.82)
+		(at 678.18 337.82)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "741af761-4a93-4e31-bf7f-b20a5ec367e3")
@@ -20120,19 +30638,19 @@
 		(uuid "79303d46-4e12-4b02-8ddb-62076a07f30b")
 	)
 	(junction
-		(at 551.18 354.33)
+		(at 504.19 411.48)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "79490d87-a19c-4a06-9e37-c0ed33502a42")
 	)
 	(junction
-		(at 778.51 316.23)
+		(at 675.64 316.23)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "7a87df7e-698e-48e9-8c41-66621ab47da8")
 	)
 	(junction
-		(at 563.88 354.33)
+		(at 516.89 411.48)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "7b5af31a-fbcc-487b-a66e-27f49d6396d9")
@@ -20156,7 +30674,7 @@
 		(uuid "7f1e4679-827a-4fc1-812b-db92288cbf37")
 	)
 	(junction
-		(at 911.86 331.47)
+		(at 843.28 382.27)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "7fc29629-95a1-44ae-865f-7b178a852dfb")
@@ -20186,7 +30704,7 @@
 		(uuid "82101e76-bed2-4b75-8a20-0e3461501d4f")
 	)
 	(junction
-		(at 558.8 386.08)
+		(at 678.18 374.65)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "849387b5-ac28-48d0-9eb0-7f08db8fea5b")
@@ -20216,7 +30734,7 @@
 		(uuid "894526b2-99de-4d05-b49e-089b61f77c4f")
 	)
 	(junction
-		(at 551.18 341.63)
+		(at 504.19 398.78)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "89638bce-13ec-45a0-a7e8-c063807ced3b")
@@ -20288,13 +30806,13 @@
 		(uuid "92b9a40b-0b14-4dd6-884c-62a0f5749e68")
 	)
 	(junction
-		(at 633.73 288.29)
+		(at 706.12 288.29)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "92de305f-29d4-459e-9b77-229d4a503dd9")
 	)
 	(junction
-		(at 416.56 351.79)
+		(at 374.65 377.19)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "9315d7e5-9a49-4a82-a258-abb6554d79bd")
@@ -20312,7 +30830,7 @@
 		(uuid "93630420-c586-4627-995d-20691fe5ff3f")
 	)
 	(junction
-		(at 633.73 193.04)
+		(at 706.12 193.04)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "93bd505c-d3fe-480c-8883-5b6a3c04297d")
@@ -20366,7 +30884,7 @@
 		(uuid "99d5a3c9-cc55-4731-9139-dc56b24665e0")
 	)
 	(junction
-		(at 652.78 274.32)
+		(at 725.17 274.32)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "99d8b3cb-165a-4644-9a7d-9905ccdf77b1")
@@ -20378,13 +30896,13 @@
 		(uuid "9a707ca4-980a-41e5-bf1e-7718a733f328")
 	)
 	(junction
-		(at 416.56 373.38)
+		(at 374.65 398.78)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "9a7553b1-63e9-4ea8-b004-02df185fb2a0")
 	)
 	(junction
-		(at 558.8 393.7)
+		(at 678.18 382.27)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "9ae7234c-c2d1-49e3-8246-1efe9b3411f6")
@@ -20402,7 +30920,7 @@
 		(uuid "9d7f0965-4b3d-431a-a312-673d2da6ebe2")
 	)
 	(junction
-		(at 551.18 191.77)
+		(at 609.6 209.55)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "9e643ad1-0f70-4fc2-b331-3de2482c8d59")
@@ -20420,25 +30938,25 @@
 		(uuid "a00ffe84-85b0-42b3-9ed5-3518d6283901")
 	)
 	(junction
-		(at 416.56 346.71)
+		(at 374.65 372.11)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "a01d40c4-0bd3-4fcb-acda-97f59e786108")
 	)
 	(junction
-		(at 551.18 328.93)
+		(at 504.19 386.08)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "a02b4740-9d5d-4fc5-ac7b-de3b87b22a0b")
 	)
 	(junction
-		(at 581.66 400.05)
+		(at 701.04 388.62)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "a12f62a1-dfd3-462b-9e8a-27c47535e59c")
 	)
 	(junction
-		(at 511.81 378.46)
+		(at 469.9 403.86)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "a1595259-1c2a-4104-8546-c12de5f6b734")
@@ -20486,7 +31004,7 @@
 		(uuid "a9d24a84-4771-451f-9edc-9832ef17adad")
 	)
 	(junction
-		(at 576.58 354.33)
+		(at 529.59 411.48)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "aa3aa73d-6850-440e-8f88-770a442eb69d")
@@ -20510,7 +31028,7 @@
 		(uuid "abd12dc7-2767-4e6a-a068-0e213fe7a3c0")
 	)
 	(junction
-		(at 563.88 341.63)
+		(at 516.89 398.78)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "ad6bf6c7-f8af-4958-888f-debfebedf200")
@@ -20534,7 +31052,7 @@
 		(uuid "ae3472f7-31fd-4a9a-8cca-07d1929816a6")
 	)
 	(junction
-		(at 436.88 369.57)
+		(at 394.97 394.97)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "ae356b66-fa3e-4253-b3be-e4931d27f73e")
@@ -20552,7 +31070,7 @@
 		(uuid "b0450f29-b285-4118-a87f-b90a9d7f0aea")
 	)
 	(junction
-		(at 657.86 406.4)
+		(at 777.24 394.97)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "b0b0a7fd-0c7d-4ce2-8d60-156a4d03315f")
@@ -20582,7 +31100,7 @@
 		(uuid "b5546f21-3642-4274-87fc-21266b037d56")
 	)
 	(junction
-		(at 911.86 359.41)
+		(at 843.28 410.21)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "b57c44b0-fb68-46ad-ac35-dfbaf81f38fc")
@@ -20600,13 +31118,13 @@
 		(uuid "b7e9049b-745e-400c-9977-f07c1da31806")
 	)
 	(junction
-		(at 449.58 411.48)
+		(at 407.67 436.88)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "b9b11f0a-2165-4377-876f-25000ef5a6ff")
 	)
 	(junction
-		(at 436.88 335.28)
+		(at 394.97 360.68)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "ba0da72e-6e55-4c5c-a7b9-02f04179373b")
@@ -20618,7 +31136,7 @@
 		(uuid "bbd85535-1f56-4eed-8a9a-e386438f706a")
 	)
 	(junction
-		(at 654.05 406.4)
+		(at 773.43 394.97)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "bdb7cdd5-2714-45fa-a8a5-b36471f5815c")
@@ -20636,7 +31154,7 @@
 		(uuid "bed7ab6f-d0b7-4a7a-ac52-c0343b9bb60e")
 	)
 	(junction
-		(at 594.36 246.38)
+		(at 666.75 246.38)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "bf04aca7-a538-4229-aebb-e5dd9989bbcf")
@@ -20648,13 +31166,13 @@
 		(uuid "bfd01905-5808-486b-9258-1091547203fe")
 	)
 	(junction
-		(at 624.84 406.4)
+		(at 744.22 394.97)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "bfefb5d3-f797-4632-b6a6-fa27d4285b29")
 	)
 	(junction
-		(at 554.99 400.05)
+		(at 674.37 388.62)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "c0e0cf06-4919-40a8-88fc-3f5ef7bef305")
@@ -20666,7 +31184,7 @@
 		(uuid "c140fdcc-4ae9-4c37-98e6-4eeca6262d48")
 	)
 	(junction
-		(at 562.61 386.08)
+		(at 681.99 374.65)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "c2c85263-3f4f-48c4-aef2-acc624f80191")
@@ -20702,13 +31220,13 @@
 		(uuid "c8ba9d60-c35f-4160-8991-a7018867c688")
 	)
 	(junction
-		(at 562.61 208.28)
+		(at 621.03 226.06)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "c8e8d6d4-2541-42a0-9928-c03cd63f580f")
 	)
 	(junction
-		(at 796.29 347.98)
+		(at 693.42 347.98)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "c954c8e5-9a62-490f-9cdc-6ec1d37e141f")
@@ -20750,7 +31268,7 @@
 		(uuid "cf60104f-9c2d-4a5f-8d12-f4f40d97f745")
 	)
 	(junction
-		(at 674.37 213.36)
+		(at 746.76 213.36)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "d0d4554e-d49a-45e2-9dad-1fb319abe65c")
@@ -20804,7 +31322,7 @@
 		(uuid "d57bfdd8-4113-45ad-ae2c-cf99e3e8e937")
 	)
 	(junction
-		(at 562.61 191.77)
+		(at 621.03 209.55)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "d5f3d870-9935-41a3-b519-6ad51de4a32a")
@@ -20822,13 +31340,13 @@
 		(uuid "d68808c7-a373-4b05-a16b-d53b9090d30b")
 	)
 	(junction
-		(at 834.39 347.98)
+		(at 731.52 347.98)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "d6b3367a-8a23-4e01-bf48-61b83c261bd8")
 	)
 	(junction
-		(at 491.49 375.92)
+		(at 449.58 401.32)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "d7b35ad5-cb48-41d7-b920-6a3630472ea7")
@@ -20840,7 +31358,7 @@
 		(uuid "d8346944-f13b-4bfb-80d9-97d1a4303bf3")
 	)
 	(junction
-		(at 688.34 231.14)
+		(at 760.73 231.14)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "d95c1ef7-6a39-4e7f-bdf9-242876334760")
@@ -20942,12 +31460,6 @@
 		(uuid "e6106834-939d-45f9-aa1b-35e2a8030fa8")
 	)
 	(junction
-		(at 712.47 347.98)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "e6d3efce-72fe-45e2-84d4-3ed900b2b6b4")
-	)
-	(junction
 		(at 86.36 44.45)
 		(diameter 0)
 		(color 0 0 0 0)
@@ -21002,7 +31514,7 @@
 		(uuid "f01a683f-f792-4e85-b700-df69f2020822")
 	)
 	(junction
-		(at 796.29 337.82)
+		(at 693.42 337.82)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "f04a75e9-13b3-4927-8e96-3627db652ec3")
@@ -21014,7 +31526,7 @@
 		(uuid "f05a8ded-3211-4164-84c3-a4d45b4535e1")
 	)
 	(junction
-		(at 541.02 341.63)
+		(at 494.03 398.78)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "f072fa55-7d31-42d2-afea-d94f142ebac1")
@@ -21038,12 +31550,6 @@
 		(uuid "f1bcee17-5760-4ad9-8d8f-3b1c4cf25d88")
 	)
 	(junction
-		(at 636.27 342.9)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "f3688c5e-53b3-4503-acb1-64859ec29ca7")
-	)
-	(junction
 		(at 281.94 635)
 		(diameter 0)
 		(color 0 0 0 0)
@@ -21056,13 +31562,13 @@
 		(uuid "f3d579b9-7c59-4ef1-b13b-bf215c70b106")
 	)
 	(junction
-		(at 576.58 341.63)
+		(at 529.59 398.78)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "f4b2b429-5be0-452d-96f3-ad67ce967762")
 	)
 	(junction
-		(at 551.18 400.05)
+		(at 670.56 388.62)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "f4c23a99-cb90-4255-893a-d6c1f6c24207")
@@ -21092,7 +31598,7 @@
 		(uuid "f792b3e3-a097-4e2e-9cfa-acf28317dacc")
 	)
 	(junction
-		(at 814.07 347.98)
+		(at 711.2 347.98)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "f91788f3-0553-4b22-b957-6d763bec50c0")
@@ -21104,7 +31610,7 @@
 		(uuid "fa1f9598-d20d-4bdf-b7ed-94902649959d")
 	)
 	(junction
-		(at 789.94 347.98)
+		(at 687.07 347.98)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "fa3ea1b3-12b4-4d15-9cc6-8ffa4d063283")
@@ -21122,7 +31628,7 @@
 		(uuid "fbb2cfa8-1fe9-42dc-bf2d-d15a8318d962")
 	)
 	(junction
-		(at 490.22 359.41)
+		(at 448.31 384.81)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "fc3360bf-85a3-457c-9350-17cfa640db05")
@@ -21146,7 +31652,7 @@
 		(uuid "fd677e2c-ddc5-4acc-bba7-e91684393f4e")
 	)
 	(junction
-		(at 834.39 337.82)
+		(at 731.52 337.82)
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "fdf64735-a40b-4450-8c74-e75fdfb60b4a")
@@ -21232,7 +31738,7 @@
 		(uuid "1eb10239-3a82-4f62-8550-5364dedffd22")
 	)
 	(no_connect
-		(at 1075.69 344.17)
+		(at 1007.11 394.97)
 		(uuid "211d1be6-59d9-454c-a178-719c8391ca45")
 	)
 	(no_connect
@@ -21260,7 +31766,7 @@
 		(uuid "2f497a98-8460-4a64-b451-750d81e20d55")
 	)
 	(no_connect
-		(at 623.57 243.84)
+		(at 695.96 243.84)
 		(uuid "304bcb8a-8c45-421f-95fa-f2e174603215")
 	)
 	(no_connect
@@ -21304,11 +31810,11 @@
 		(uuid "464a9d60-b0ba-495c-8cc4-77789eff0b7c")
 	)
 	(no_connect
-		(at 1075.69 341.63)
+		(at 1007.11 392.43)
 		(uuid "48154427-4ad6-458f-a3c1-d4e0e69c7218")
 	)
 	(no_connect
-		(at 651.51 335.28)
+		(at 581.66 389.89)
 		(uuid "485bcb34-4a6f-4813-a197-6c2912c02d9d")
 	)
 	(no_connect
@@ -21464,7 +31970,7 @@
 		(uuid "8ae281e2-bfec-4810-b0c8-651cf31ddb8d")
 	)
 	(no_connect
-		(at 1040.13 344.17)
+		(at 971.55 394.97)
 		(uuid "8d4528e2-3837-4d2e-be23-9da21081e24c")
 	)
 	(no_connect
@@ -21536,7 +32042,7 @@
 		(uuid "a7c5ef6b-5415-4919-9817-62642bac4113")
 	)
 	(no_connect
-		(at 582.93 394.97)
+		(at 702.31 383.54)
 		(uuid "a83d3acc-352e-417f-be05-d560d2a4f499")
 	)
 	(no_connect
@@ -21604,7 +32110,7 @@
 		(uuid "b9f477df-d7da-426b-a9a0-143714018f66")
 	)
 	(no_connect
-		(at 1040.13 336.55)
+		(at 971.55 387.35)
 		(uuid "bd43141e-1c1c-4ba4-bf54-13ac546ef84c")
 	)
 	(no_connect
@@ -21672,7 +32178,7 @@
 		(uuid "cc27943f-9aeb-4523-a452-6606a52370ad")
 	)
 	(no_connect
-		(at 651.51 350.52)
+		(at 581.66 405.13)
 		(uuid "cc770347-d801-4660-a189-3ec5bb550bcd")
 	)
 	(no_connect
@@ -21835,7 +32341,7 @@
 	)
 	(wire
 		(pts
-			(xy 723.9 337.82) (xy 723.9 340.36)
+			(xy 654.05 392.43) (xy 654.05 394.97)
 		)
 		(stroke
 			(width 0)
@@ -21845,7 +32351,7 @@
 	)
 	(wire
 		(pts
-			(xy 645.16 353.06) (xy 651.51 353.06)
+			(xy 575.31 407.67) (xy 581.66 407.67)
 		)
 		(stroke
 			(width 0)
@@ -21855,7 +32361,7 @@
 	)
 	(wire
 		(pts
-			(xy 426.72 378.46) (xy 436.88 378.46)
+			(xy 384.81 403.86) (xy 394.97 403.86)
 		)
 		(stroke
 			(width 0)
@@ -21875,7 +32381,7 @@
 	)
 	(wire
 		(pts
-			(xy 554.99 400.05) (xy 581.66 400.05)
+			(xy 674.37 388.62) (xy 701.04 388.62)
 		)
 		(stroke
 			(width 0)
@@ -21905,7 +32411,7 @@
 	)
 	(wire
 		(pts
-			(xy 859.79 347.98) (xy 848.36 347.98)
+			(xy 756.92 347.98) (xy 745.49 347.98)
 		)
 		(stroke
 			(width 0)
@@ -21945,7 +32451,7 @@
 	)
 	(wire
 		(pts
-			(xy 623.57 405.13) (xy 624.84 405.13)
+			(xy 742.95 393.7) (xy 744.22 393.7)
 		)
 		(stroke
 			(width 0)
@@ -21995,7 +32501,7 @@
 	)
 	(wire
 		(pts
-			(xy 635 400.05) (xy 623.57 400.05)
+			(xy 754.38 388.62) (xy 742.95 388.62)
 		)
 		(stroke
 			(width 0)
@@ -22015,7 +32521,7 @@
 	)
 	(wire
 		(pts
-			(xy 416.56 363.22) (xy 416.56 365.76)
+			(xy 374.65 388.62) (xy 374.65 391.16)
 		)
 		(stroke
 			(width 0)
@@ -22055,7 +32561,7 @@
 	)
 	(wire
 		(pts
-			(xy 778.51 316.23) (xy 778.51 339.09)
+			(xy 675.64 316.23) (xy 675.64 339.09)
 		)
 		(stroke
 			(width 0)
@@ -22065,7 +32571,7 @@
 	)
 	(wire
 		(pts
-			(xy 920.75 359.41) (xy 924.56 359.41)
+			(xy 852.17 410.21) (xy 855.98 410.21)
 		)
 		(stroke
 			(width 0)
@@ -22095,7 +32601,7 @@
 	)
 	(wire
 		(pts
-			(xy 480.06 370.84) (xy 482.6 370.84)
+			(xy 438.15 396.24) (xy 440.69 396.24)
 		)
 		(stroke
 			(width 0)
@@ -22135,7 +32641,7 @@
 	)
 	(wire
 		(pts
-			(xy 482.6 370.84) (xy 480.06 368.3)
+			(xy 440.69 396.24) (xy 438.15 393.7)
 		)
 		(stroke
 			(width 0)
@@ -22155,7 +32661,7 @@
 	)
 	(wire
 		(pts
-			(xy 674.37 213.36) (xy 676.91 213.36)
+			(xy 746.76 213.36) (xy 749.3 213.36)
 		)
 		(stroke
 			(width 0)
@@ -22175,7 +32681,7 @@
 	)
 	(wire
 		(pts
-			(xy 566.42 328.93) (xy 563.88 328.93)
+			(xy 519.43 386.08) (xy 516.89 386.08)
 		)
 		(stroke
 			(width 0)
@@ -22185,7 +32691,7 @@
 	)
 	(wire
 		(pts
-			(xy 491.49 374.65) (xy 491.49 375.92)
+			(xy 449.58 400.05) (xy 449.58 401.32)
 		)
 		(stroke
 			(width 0)
@@ -22195,7 +32701,7 @@
 	)
 	(wire
 		(pts
-			(xy 425.45 346.71) (xy 426.72 346.71)
+			(xy 383.54 372.11) (xy 384.81 372.11)
 		)
 		(stroke
 			(width 0)
@@ -22205,7 +32711,7 @@
 	)
 	(wire
 		(pts
-			(xy 459.74 326.39) (xy 459.74 335.28)
+			(xy 417.83 351.79) (xy 417.83 360.68)
 		)
 		(stroke
 			(width 0)
@@ -22305,7 +32811,7 @@
 	)
 	(wire
 		(pts
-			(xy 575.31 392.43) (xy 582.93 392.43)
+			(xy 694.69 381) (xy 702.31 381)
 		)
 		(stroke
 			(width 0)
@@ -22315,7 +32821,7 @@
 	)
 	(wire
 		(pts
-			(xy 511.81 222.25) (xy 511.81 231.14)
+			(xy 609.6 256.54) (xy 609.6 265.43)
 		)
 		(stroke
 			(width 0)
@@ -22335,7 +32841,7 @@
 	)
 	(wire
 		(pts
-			(xy 645.16 415.29) (xy 632.46 415.29)
+			(xy 764.54 403.86) (xy 751.84 403.86)
 		)
 		(stroke
 			(width 0)
@@ -22415,7 +32921,7 @@
 	)
 	(wire
 		(pts
-			(xy 515.62 222.25) (xy 511.81 222.25)
+			(xy 613.41 256.54) (xy 609.6 256.54)
 		)
 		(stroke
 			(width 0)
@@ -22435,7 +32941,7 @@
 	)
 	(wire
 		(pts
-			(xy 553.72 354.33) (xy 551.18 354.33)
+			(xy 506.73 411.48) (xy 504.19 411.48)
 		)
 		(stroke
 			(width 0)
@@ -22445,7 +32951,7 @@
 	)
 	(wire
 		(pts
-			(xy 571.5 386.08) (xy 571.5 389.89)
+			(xy 690.88 374.65) (xy 690.88 378.46)
 		)
 		(stroke
 			(width 0)
@@ -22485,7 +32991,7 @@
 	)
 	(wire
 		(pts
-			(xy 640.08 327.66) (xy 642.62 327.66)
+			(xy 570.23 382.27) (xy 572.77 382.27)
 		)
 		(stroke
 			(width 0)
@@ -22515,7 +33021,7 @@
 	)
 	(wire
 		(pts
-			(xy 571.5 389.89) (xy 582.93 389.89)
+			(xy 690.88 378.46) (xy 702.31 378.46)
 		)
 		(stroke
 			(width 0)
@@ -22525,7 +33031,7 @@
 	)
 	(wire
 		(pts
-			(xy 675.64 265.43) (xy 678.18 265.43)
+			(xy 748.03 265.43) (xy 750.57 265.43)
 		)
 		(stroke
 			(width 0)
@@ -22535,7 +33041,7 @@
 	)
 	(wire
 		(pts
-			(xy 605.79 241.3) (xy 623.57 241.3)
+			(xy 678.18 241.3) (xy 695.96 241.3)
 		)
 		(stroke
 			(width 0)
@@ -22545,7 +33051,7 @@
 	)
 	(wire
 		(pts
-			(xy 683.26 243.84) (xy 659.13 243.84)
+			(xy 755.65 243.84) (xy 731.52 243.84)
 		)
 		(stroke
 			(width 0)
@@ -22605,7 +33111,7 @@
 	)
 	(wire
 		(pts
-			(xy 605.79 233.68) (xy 623.57 233.68)
+			(xy 678.18 233.68) (xy 695.96 233.68)
 		)
 		(stroke
 			(width 0)
@@ -22625,7 +33131,7 @@
 	)
 	(wire
 		(pts
-			(xy 703.58 332.74) (xy 702.31 332.74)
+			(xy 633.73 387.35) (xy 632.46 387.35)
 		)
 		(stroke
 			(width 0)
@@ -22675,7 +33181,7 @@
 	)
 	(wire
 		(pts
-			(xy 551.18 354.33) (xy 551.18 351.79)
+			(xy 504.19 411.48) (xy 504.19 408.94)
 		)
 		(stroke
 			(width 0)
@@ -22685,7 +33191,7 @@
 	)
 	(wire
 		(pts
-			(xy 530.86 354.33) (xy 541.02 354.33)
+			(xy 483.87 411.48) (xy 494.03 411.48)
 		)
 		(stroke
 			(width 0)
@@ -22695,7 +33201,7 @@
 	)
 	(wire
 		(pts
-			(xy 723.9 340.36) (xy 711.2 340.36)
+			(xy 654.05 394.97) (xy 641.35 394.97)
 		)
 		(stroke
 			(width 0)
@@ -22705,7 +33211,7 @@
 	)
 	(wire
 		(pts
-			(xy 678.18 265.43) (xy 680.72 265.43)
+			(xy 750.57 265.43) (xy 753.11 265.43)
 		)
 		(stroke
 			(width 0)
@@ -22735,7 +33241,7 @@
 	)
 	(wire
 		(pts
-			(xy 834.39 347.98) (xy 840.74 347.98)
+			(xy 731.52 347.98) (xy 737.87 347.98)
 		)
 		(stroke
 			(width 0)
@@ -22755,7 +33261,7 @@
 	)
 	(wire
 		(pts
-			(xy 579.12 354.33) (xy 576.58 354.33)
+			(xy 532.13 411.48) (xy 529.59 411.48)
 		)
 		(stroke
 			(width 0)
@@ -22765,7 +33271,7 @@
 	)
 	(wire
 		(pts
-			(xy 781.05 337.82) (xy 789.94 337.82)
+			(xy 678.18 337.82) (xy 687.07 337.82)
 		)
 		(stroke
 			(width 0)
@@ -22795,7 +33301,7 @@
 	)
 	(wire
 		(pts
-			(xy 416.56 351.79) (xy 417.83 351.79)
+			(xy 374.65 377.19) (xy 375.92 377.19)
 		)
 		(stroke
 			(width 0)
@@ -22805,7 +33311,7 @@
 	)
 	(wire
 		(pts
-			(xy 561.34 191.77) (xy 562.61 191.77)
+			(xy 619.76 209.55) (xy 621.03 209.55)
 		)
 		(stroke
 			(width 0)
@@ -22815,7 +33321,7 @@
 	)
 	(wire
 		(pts
-			(xy 472.44 410.21) (xy 472.44 401.32)
+			(xy 430.53 435.61) (xy 430.53 426.72)
 		)
 		(stroke
 			(width 0)
@@ -22835,7 +33341,7 @@
 	)
 	(wire
 		(pts
-			(xy 651.51 327.66) (xy 650.24 327.66)
+			(xy 581.66 382.27) (xy 580.39 382.27)
 		)
 		(stroke
 			(width 0)
@@ -22845,7 +33351,7 @@
 	)
 	(wire
 		(pts
-			(xy 530.86 328.93) (xy 541.02 328.93)
+			(xy 483.87 386.08) (xy 494.03 386.08)
 		)
 		(stroke
 			(width 0)
@@ -22855,7 +33361,7 @@
 	)
 	(wire
 		(pts
-			(xy 416.56 363.22) (xy 436.88 363.22)
+			(xy 374.65 388.62) (xy 394.97 388.62)
 		)
 		(stroke
 			(width 0)
@@ -22945,7 +33451,7 @@
 	)
 	(wire
 		(pts
-			(xy 436.88 369.57) (xy 436.88 368.3)
+			(xy 394.97 394.97) (xy 394.97 393.7)
 		)
 		(stroke
 			(width 0)
@@ -23055,7 +33561,7 @@
 	)
 	(wire
 		(pts
-			(xy 576.58 406.4) (xy 576.58 407.67)
+			(xy 695.96 394.97) (xy 695.96 396.24)
 		)
 		(stroke
 			(width 0)
@@ -23065,7 +33571,7 @@
 	)
 	(wire
 		(pts
-			(xy 576.58 318.77) (xy 576.58 316.23)
+			(xy 529.59 375.92) (xy 529.59 373.38)
 		)
 		(stroke
 			(width 0)
@@ -23075,7 +33581,7 @@
 	)
 	(wire
 		(pts
-			(xy 899.16 359.41) (xy 911.86 359.41)
+			(xy 830.58 410.21) (xy 843.28 410.21)
 		)
 		(stroke
 			(width 0)
@@ -23085,7 +33591,7 @@
 	)
 	(wire
 		(pts
-			(xy 1155.7 342.9) (xy 1158.24 342.9)
+			(xy 1087.12 393.7) (xy 1089.66 393.7)
 		)
 		(stroke
 			(width 0)
@@ -23095,7 +33601,7 @@
 	)
 	(wire
 		(pts
-			(xy 762 337.82) (xy 781.05 337.82)
+			(xy 659.13 337.82) (xy 678.18 337.82)
 		)
 		(stroke
 			(width 0)
@@ -23145,7 +33651,7 @@
 	)
 	(wire
 		(pts
-			(xy 651.51 325.12) (xy 640.08 325.12)
+			(xy 581.66 379.73) (xy 570.23 379.73)
 		)
 		(stroke
 			(width 0)
@@ -23165,7 +33671,7 @@
 	)
 	(wire
 		(pts
-			(xy 581.66 397.51) (xy 582.93 397.51)
+			(xy 701.04 386.08) (xy 702.31 386.08)
 		)
 		(stroke
 			(width 0)
@@ -23175,7 +33681,7 @@
 	)
 	(wire
 		(pts
-			(xy 638.81 284.48) (xy 638.81 274.32)
+			(xy 711.2 284.48) (xy 711.2 274.32)
 		)
 		(stroke
 			(width 0)
@@ -23215,7 +33721,7 @@
 	)
 	(wire
 		(pts
-			(xy 541.02 328.93) (xy 541.02 326.39)
+			(xy 494.03 386.08) (xy 494.03 383.54)
 		)
 		(stroke
 			(width 0)
@@ -23225,7 +33731,7 @@
 	)
 	(wire
 		(pts
-			(xy 1160.78 342.9) (xy 1163.32 342.9)
+			(xy 1092.2 393.7) (xy 1094.74 393.7)
 		)
 		(stroke
 			(width 0)
@@ -23245,7 +33751,7 @@
 	)
 	(wire
 		(pts
-			(xy 551.18 191.77) (xy 553.72 191.77)
+			(xy 609.6 209.55) (xy 612.14 209.55)
 		)
 		(stroke
 			(width 0)
@@ -23275,7 +33781,7 @@
 	)
 	(wire
 		(pts
-			(xy 511.81 220.98) (xy 511.81 222.25)
+			(xy 609.6 255.27) (xy 609.6 256.54)
 		)
 		(stroke
 			(width 0)
@@ -23285,7 +33791,7 @@
 	)
 	(wire
 		(pts
-			(xy 661.67 406.4) (xy 657.86 406.4)
+			(xy 781.05 394.97) (xy 777.24 394.97)
 		)
 		(stroke
 			(width 0)
@@ -23335,7 +33841,7 @@
 	)
 	(wire
 		(pts
-			(xy 807.72 337.82) (xy 814.07 337.82)
+			(xy 704.85 337.82) (xy 711.2 337.82)
 		)
 		(stroke
 			(width 0)
@@ -23385,7 +33891,7 @@
 	)
 	(wire
 		(pts
-			(xy 551.18 208.28) (xy 539.75 208.28)
+			(xy 609.6 226.06) (xy 598.17 226.06)
 		)
 		(stroke
 			(width 0)
@@ -23425,7 +33931,7 @@
 	)
 	(wire
 		(pts
-			(xy 558.8 386.08) (xy 562.61 386.08)
+			(xy 678.18 374.65) (xy 681.99 374.65)
 		)
 		(stroke
 			(width 0)
@@ -23465,7 +33971,7 @@
 	)
 	(wire
 		(pts
-			(xy 427.99 358.14) (xy 436.88 358.14)
+			(xy 386.08 383.54) (xy 394.97 383.54)
 		)
 		(stroke
 			(width 0)
@@ -23505,7 +34011,7 @@
 	)
 	(wire
 		(pts
-			(xy 441.96 328.93) (xy 449.58 328.93)
+			(xy 400.05 354.33) (xy 407.67 354.33)
 		)
 		(stroke
 			(width 0)
@@ -23555,7 +34061,7 @@
 	)
 	(wire
 		(pts
-			(xy 563.88 318.77) (xy 563.88 316.23)
+			(xy 516.89 375.92) (xy 516.89 373.38)
 		)
 		(stroke
 			(width 0)
@@ -23585,7 +34091,7 @@
 	)
 	(wire
 		(pts
-			(xy 511.81 378.46) (xy 509.27 378.46)
+			(xy 469.9 403.86) (xy 467.36 403.86)
 		)
 		(stroke
 			(width 0)
@@ -23595,7 +34101,7 @@
 	)
 	(wire
 		(pts
-			(xy 685.8 238.76) (xy 688.34 238.76)
+			(xy 758.19 238.76) (xy 760.73 238.76)
 		)
 		(stroke
 			(width 0)
@@ -23625,7 +34131,7 @@
 	)
 	(wire
 		(pts
-			(xy 723.9 337.82) (xy 702.31 337.82)
+			(xy 654.05 392.43) (xy 632.46 392.43)
 		)
 		(stroke
 			(width 0)
@@ -23665,7 +34171,7 @@
 	)
 	(wire
 		(pts
-			(xy 563.88 328.93) (xy 561.34 328.93)
+			(xy 516.89 386.08) (xy 514.35 386.08)
 		)
 		(stroke
 			(width 0)
@@ -23695,7 +34201,7 @@
 	)
 	(wire
 		(pts
-			(xy 425.45 341.63) (xy 425.45 346.71)
+			(xy 383.54 367.03) (xy 383.54 372.11)
 		)
 		(stroke
 			(width 0)
@@ -23715,7 +34221,7 @@
 	)
 	(wire
 		(pts
-			(xy 530.86 341.63) (xy 541.02 341.63)
+			(xy 483.87 398.78) (xy 494.03 398.78)
 		)
 		(stroke
 			(width 0)
@@ -23745,7 +34251,7 @@
 	)
 	(wire
 		(pts
-			(xy 1082.04 339.09) (xy 1075.69 339.09)
+			(xy 1013.46 389.89) (xy 1007.11 389.89)
 		)
 		(stroke
 			(width 0)
@@ -23765,7 +34271,7 @@
 	)
 	(wire
 		(pts
-			(xy 661.67 414.02) (xy 657.86 414.02)
+			(xy 781.05 402.59) (xy 777.24 402.59)
 		)
 		(stroke
 			(width 0)
@@ -23775,7 +34281,7 @@
 	)
 	(wire
 		(pts
-			(xy 563.88 406.4) (xy 576.58 406.4)
+			(xy 683.26 394.97) (xy 695.96 394.97)
 		)
 		(stroke
 			(width 0)
@@ -23825,7 +34331,7 @@
 	)
 	(wire
 		(pts
-			(xy 645.16 412.75) (xy 632.46 412.75)
+			(xy 764.54 401.32) (xy 751.84 401.32)
 		)
 		(stroke
 			(width 0)
@@ -23835,7 +34341,7 @@
 	)
 	(wire
 		(pts
-			(xy 562.61 204.47) (xy 562.61 208.28)
+			(xy 621.03 222.25) (xy 621.03 226.06)
 		)
 		(stroke
 			(width 0)
@@ -23845,7 +34351,7 @@
 	)
 	(wire
 		(pts
-			(xy 678.18 257.81) (xy 680.72 257.81)
+			(xy 750.57 257.81) (xy 753.11 257.81)
 		)
 		(stroke
 			(width 0)
@@ -23855,7 +34361,7 @@
 	)
 	(wire
 		(pts
-			(xy 427.99 360.68) (xy 436.88 360.68)
+			(xy 386.08 386.08) (xy 394.97 386.08)
 		)
 		(stroke
 			(width 0)
@@ -23875,7 +34381,7 @@
 	)
 	(wire
 		(pts
-			(xy 551.18 318.77) (xy 551.18 316.23)
+			(xy 504.19 375.92) (xy 504.19 373.38)
 		)
 		(stroke
 			(width 0)
@@ -23885,7 +34391,7 @@
 	)
 	(wire
 		(pts
-			(xy 480.06 363.22) (xy 485.14 363.22)
+			(xy 438.15 388.62) (xy 443.23 388.62)
 		)
 		(stroke
 			(width 0)
@@ -23955,7 +34461,7 @@
 	)
 	(wire
 		(pts
-			(xy 462.28 410.21) (xy 462.28 401.32)
+			(xy 420.37 435.61) (xy 420.37 426.72)
 		)
 		(stroke
 			(width 0)
@@ -23965,7 +34471,7 @@
 	)
 	(wire
 		(pts
-			(xy 1080.77 328.93) (xy 1080.77 336.55)
+			(xy 1012.19 379.73) (xy 1012.19 387.35)
 		)
 		(stroke
 			(width 0)
@@ -24005,7 +34511,7 @@
 	)
 	(wire
 		(pts
-			(xy 603.25 354.33) (xy 596.9 354.33)
+			(xy 556.26 411.48) (xy 549.91 411.48)
 		)
 		(stroke
 			(width 0)
@@ -24025,7 +34531,7 @@
 	)
 	(wire
 		(pts
-			(xy 551.18 328.93) (xy 541.02 328.93)
+			(xy 504.19 386.08) (xy 494.03 386.08)
 		)
 		(stroke
 			(width 0)
@@ -24055,7 +34561,7 @@
 	)
 	(wire
 		(pts
-			(xy 457.2 326.39) (xy 457.2 335.28)
+			(xy 415.29 351.79) (xy 415.29 360.68)
 		)
 		(stroke
 			(width 0)
@@ -24085,7 +34591,7 @@
 	)
 	(wire
 		(pts
-			(xy 633.73 193.04) (xy 633.73 200.66)
+			(xy 706.12 193.04) (xy 706.12 200.66)
 		)
 		(stroke
 			(width 0)
@@ -24105,7 +34611,7 @@
 	)
 	(wire
 		(pts
-			(xy 659.13 246.38) (xy 678.18 246.38)
+			(xy 731.52 246.38) (xy 750.57 246.38)
 		)
 		(stroke
 			(width 0)
@@ -24115,7 +34621,7 @@
 	)
 	(wire
 		(pts
-			(xy 464.82 326.39) (xy 464.82 335.28)
+			(xy 422.91 351.79) (xy 422.91 360.68)
 		)
 		(stroke
 			(width 0)
@@ -24125,7 +34631,7 @@
 	)
 	(wire
 		(pts
-			(xy 723.9 335.28) (xy 723.9 332.74)
+			(xy 654.05 389.89) (xy 654.05 387.35)
 		)
 		(stroke
 			(width 0)
@@ -24175,7 +34681,7 @@
 	)
 	(wire
 		(pts
-			(xy 515.62 220.98) (xy 515.62 222.25)
+			(xy 613.41 255.27) (xy 613.41 256.54)
 		)
 		(stroke
 			(width 0)
@@ -24205,7 +34711,7 @@
 	)
 	(wire
 		(pts
-			(xy 605.79 248.92) (xy 623.57 248.92)
+			(xy 678.18 248.92) (xy 695.96 248.92)
 		)
 		(stroke
 			(width 0)
@@ -24225,7 +34731,7 @@
 	)
 	(wire
 		(pts
-			(xy 648.97 175.26) (xy 648.97 200.66)
+			(xy 721.36 175.26) (xy 721.36 200.66)
 		)
 		(stroke
 			(width 0)
@@ -24235,7 +34741,7 @@
 	)
 	(wire
 		(pts
-			(xy 581.66 400.05) (xy 581.66 402.59)
+			(xy 701.04 388.62) (xy 701.04 391.16)
 		)
 		(stroke
 			(width 0)
@@ -24255,7 +34761,7 @@
 	)
 	(wire
 		(pts
-			(xy 654.05 406.4) (xy 657.86 406.4)
+			(xy 773.43 394.97) (xy 777.24 394.97)
 		)
 		(stroke
 			(width 0)
@@ -24285,7 +34791,7 @@
 	)
 	(wire
 		(pts
-			(xy 431.8 369.57) (xy 436.88 369.57)
+			(xy 389.89 394.97) (xy 394.97 394.97)
 		)
 		(stroke
 			(width 0)
@@ -24305,7 +34811,7 @@
 	)
 	(wire
 		(pts
-			(xy 547.37 400.05) (xy 551.18 400.05)
+			(xy 666.75 388.62) (xy 670.56 388.62)
 		)
 		(stroke
 			(width 0)
@@ -24375,7 +34881,7 @@
 	)
 	(wire
 		(pts
-			(xy 828.04 347.98) (xy 834.39 347.98)
+			(xy 725.17 347.98) (xy 731.52 347.98)
 		)
 		(stroke
 			(width 0)
@@ -24395,7 +34901,7 @@
 	)
 	(wire
 		(pts
-			(xy 708.66 350.52) (xy 702.31 350.52)
+			(xy 638.81 405.13) (xy 632.46 405.13)
 		)
 		(stroke
 			(width 0)
@@ -24415,7 +34921,7 @@
 	)
 	(wire
 		(pts
-			(xy 416.56 341.63) (xy 416.56 346.71)
+			(xy 374.65 367.03) (xy 374.65 372.11)
 		)
 		(stroke
 			(width 0)
@@ -24425,7 +34931,7 @@
 	)
 	(wire
 		(pts
-			(xy 563.88 344.17) (xy 563.88 341.63)
+			(xy 516.89 401.32) (xy 516.89 398.78)
 		)
 		(stroke
 			(width 0)
@@ -24445,7 +34951,7 @@
 	)
 	(wire
 		(pts
-			(xy 563.88 411.48) (xy 576.58 411.48)
+			(xy 683.26 400.05) (xy 695.96 400.05)
 		)
 		(stroke
 			(width 0)
@@ -24465,7 +34971,7 @@
 	)
 	(wire
 		(pts
-			(xy 711.2 332.74) (xy 723.9 332.74)
+			(xy 641.35 387.35) (xy 654.05 387.35)
 		)
 		(stroke
 			(width 0)
@@ -24555,7 +35061,7 @@
 	)
 	(wire
 		(pts
-			(xy 624.84 406.4) (xy 654.05 406.4)
+			(xy 744.22 394.97) (xy 773.43 394.97)
 		)
 		(stroke
 			(width 0)
@@ -24585,7 +35091,7 @@
 	)
 	(wire
 		(pts
-			(xy 646.43 284.48) (xy 646.43 274.32)
+			(xy 718.82 284.48) (xy 718.82 274.32)
 		)
 		(stroke
 			(width 0)
@@ -24595,7 +35101,7 @@
 	)
 	(wire
 		(pts
-			(xy 654.05 414.02) (xy 657.86 414.02)
+			(xy 773.43 402.59) (xy 777.24 402.59)
 		)
 		(stroke
 			(width 0)
@@ -24645,7 +35151,7 @@
 	)
 	(wire
 		(pts
-			(xy 562.61 191.77) (xy 562.61 196.85)
+			(xy 621.03 209.55) (xy 621.03 214.63)
 		)
 		(stroke
 			(width 0)
@@ -24655,7 +35161,7 @@
 	)
 	(wire
 		(pts
-			(xy 488.95 355.6) (xy 480.06 355.6)
+			(xy 447.04 381) (xy 438.15 381)
 		)
 		(stroke
 			(width 0)
@@ -24675,7 +35181,7 @@
 	)
 	(wire
 		(pts
-			(xy 454.66 320.04) (xy 454.66 335.28)
+			(xy 412.75 345.44) (xy 412.75 360.68)
 		)
 		(stroke
 			(width 0)
@@ -24695,7 +35201,7 @@
 	)
 	(wire
 		(pts
-			(xy 662.94 236.22) (xy 659.13 236.22)
+			(xy 735.33 236.22) (xy 731.52 236.22)
 		)
 		(stroke
 			(width 0)
@@ -24735,7 +35241,7 @@
 	)
 	(wire
 		(pts
-			(xy 576.58 354.33) (xy 576.58 351.79)
+			(xy 529.59 411.48) (xy 529.59 408.94)
 		)
 		(stroke
 			(width 0)
@@ -24745,7 +35251,7 @@
 	)
 	(wire
 		(pts
-			(xy 641.35 340.36) (xy 651.51 340.36)
+			(xy 571.5 394.97) (xy 581.66 394.97)
 		)
 		(stroke
 			(width 0)
@@ -24785,7 +35291,7 @@
 	)
 	(wire
 		(pts
-			(xy 623.57 415.29) (xy 624.84 415.29)
+			(xy 742.95 403.86) (xy 744.22 403.86)
 		)
 		(stroke
 			(width 0)
@@ -24795,7 +35301,7 @@
 	)
 	(wire
 		(pts
-			(xy 416.56 372.11) (xy 416.56 373.38)
+			(xy 374.65 397.51) (xy 374.65 398.78)
 		)
 		(stroke
 			(width 0)
@@ -24885,7 +35391,7 @@
 	)
 	(wire
 		(pts
-			(xy 449.58 412.75) (xy 449.58 411.48)
+			(xy 407.67 438.15) (xy 407.67 436.88)
 		)
 		(stroke
 			(width 0)
@@ -24955,7 +35461,7 @@
 	)
 	(wire
 		(pts
-			(xy 459.74 410.21) (xy 459.74 401.32)
+			(xy 417.83 435.61) (xy 417.83 426.72)
 		)
 		(stroke
 			(width 0)
@@ -24965,7 +35471,7 @@
 	)
 	(wire
 		(pts
-			(xy 1080.77 317.5) (xy 1085.85 317.5)
+			(xy 1012.19 368.3) (xy 1017.27 368.3)
 		)
 		(stroke
 			(width 0)
@@ -25005,7 +35511,7 @@
 	)
 	(wire
 		(pts
-			(xy 778.51 346.71) (xy 778.51 347.98)
+			(xy 675.64 346.71) (xy 675.64 347.98)
 		)
 		(stroke
 			(width 0)
@@ -25055,7 +35561,7 @@
 	)
 	(wire
 		(pts
-			(xy 467.36 326.39) (xy 467.36 335.28)
+			(xy 425.45 351.79) (xy 425.45 360.68)
 		)
 		(stroke
 			(width 0)
@@ -25065,7 +35571,7 @@
 	)
 	(wire
 		(pts
-			(xy 662.94 228.6) (xy 662.94 236.22)
+			(xy 735.33 228.6) (xy 735.33 236.22)
 		)
 		(stroke
 			(width 0)
@@ -25085,7 +35591,7 @@
 	)
 	(wire
 		(pts
-			(xy 796.29 347.98) (xy 800.1 347.98)
+			(xy 693.42 347.98) (xy 697.23 347.98)
 		)
 		(stroke
 			(width 0)
@@ -25135,7 +35641,7 @@
 	)
 	(wire
 		(pts
-			(xy 659.13 212.09) (xy 659.13 233.68)
+			(xy 731.52 212.09) (xy 731.52 233.68)
 		)
 		(stroke
 			(width 0)
@@ -25165,7 +35671,7 @@
 	)
 	(wire
 		(pts
-			(xy 623.57 397.51) (xy 635 397.51)
+			(xy 742.95 386.08) (xy 754.38 386.08)
 		)
 		(stroke
 			(width 0)
@@ -25275,7 +35781,7 @@
 	)
 	(wire
 		(pts
-			(xy 541.02 344.17) (xy 541.02 341.63)
+			(xy 494.03 401.32) (xy 494.03 398.78)
 		)
 		(stroke
 			(width 0)
@@ -25295,7 +35801,7 @@
 	)
 	(wire
 		(pts
-			(xy 675.64 257.81) (xy 678.18 257.81)
+			(xy 748.03 257.81) (xy 750.57 257.81)
 		)
 		(stroke
 			(width 0)
@@ -25335,7 +35841,7 @@
 	)
 	(wire
 		(pts
-			(xy 623.57 394.97) (xy 624.84 394.97)
+			(xy 742.95 383.54) (xy 744.22 383.54)
 		)
 		(stroke
 			(width 0)
@@ -25355,7 +35861,7 @@
 	)
 	(wire
 		(pts
-			(xy 558.8 393.7) (xy 562.61 393.7)
+			(xy 678.18 382.27) (xy 681.99 382.27)
 		)
 		(stroke
 			(width 0)
@@ -25395,7 +35901,7 @@
 	)
 	(wire
 		(pts
-			(xy 643.89 170.18) (xy 643.89 200.66)
+			(xy 716.28 170.18) (xy 716.28 200.66)
 		)
 		(stroke
 			(width 0)
@@ -25485,7 +35991,7 @@
 	)
 	(wire
 		(pts
-			(xy 563.88 328.93) (xy 563.88 326.39)
+			(xy 516.89 386.08) (xy 516.89 383.54)
 		)
 		(stroke
 			(width 0)
@@ -25495,7 +36001,7 @@
 	)
 	(wire
 		(pts
-			(xy 576.58 354.33) (xy 574.04 354.33)
+			(xy 529.59 411.48) (xy 527.05 411.48)
 		)
 		(stroke
 			(width 0)
@@ -25545,7 +36051,7 @@
 	)
 	(wire
 		(pts
-			(xy 581.66 405.13) (xy 582.93 405.13)
+			(xy 701.04 393.7) (xy 702.31 393.7)
 		)
 		(stroke
 			(width 0)
@@ -25555,7 +36061,7 @@
 	)
 	(wire
 		(pts
-			(xy 563.88 354.33) (xy 563.88 351.79)
+			(xy 516.89 411.48) (xy 516.89 408.94)
 		)
 		(stroke
 			(width 0)
@@ -25575,7 +36081,7 @@
 	)
 	(wire
 		(pts
-			(xy 834.39 337.82) (xy 840.74 337.82)
+			(xy 731.52 337.82) (xy 737.87 337.82)
 		)
 		(stroke
 			(width 0)
@@ -25615,7 +36121,7 @@
 	)
 	(wire
 		(pts
-			(xy 551.18 199.39) (xy 551.18 200.66)
+			(xy 609.6 217.17) (xy 609.6 218.44)
 		)
 		(stroke
 			(width 0)
@@ -25695,7 +36201,7 @@
 	)
 	(wire
 		(pts
-			(xy 416.56 341.63) (xy 417.83 341.63)
+			(xy 374.65 367.03) (xy 375.92 367.03)
 		)
 		(stroke
 			(width 0)
@@ -25765,7 +36271,7 @@
 	)
 	(wire
 		(pts
-			(xy 778.51 312.42) (xy 802.64 312.42)
+			(xy 675.64 312.42) (xy 699.77 312.42)
 		)
 		(stroke
 			(width 0)
@@ -25775,7 +36281,7 @@
 	)
 	(wire
 		(pts
-			(xy 576.58 316.23) (xy 574.04 316.23)
+			(xy 529.59 373.38) (xy 527.05 373.38)
 		)
 		(stroke
 			(width 0)
@@ -25795,7 +36301,7 @@
 	)
 	(wire
 		(pts
-			(xy 623.57 412.75) (xy 624.84 412.75)
+			(xy 742.95 401.32) (xy 744.22 401.32)
 		)
 		(stroke
 			(width 0)
@@ -25865,7 +36371,7 @@
 	)
 	(wire
 		(pts
-			(xy 539.75 191.77) (xy 551.18 191.77)
+			(xy 598.17 209.55) (xy 609.6 209.55)
 		)
 		(stroke
 			(width 0)
@@ -25885,7 +36391,7 @@
 	)
 	(wire
 		(pts
-			(xy 436.88 335.28) (xy 436.88 336.55)
+			(xy 394.97 360.68) (xy 394.97 361.95)
 		)
 		(stroke
 			(width 0)
@@ -25895,7 +36401,7 @@
 	)
 	(wire
 		(pts
-			(xy 490.22 358.14) (xy 490.22 359.41)
+			(xy 448.31 383.54) (xy 448.31 384.81)
 		)
 		(stroke
 			(width 0)
@@ -25905,7 +36411,7 @@
 	)
 	(wire
 		(pts
-			(xy 1036.32 341.63) (xy 1040.13 341.63)
+			(xy 967.74 392.43) (xy 971.55 392.43)
 		)
 		(stroke
 			(width 0)
@@ -25935,7 +36441,7 @@
 	)
 	(wire
 		(pts
-			(xy 434.34 402.59) (xy 434.34 403.86)
+			(xy 392.43 427.99) (xy 392.43 429.26)
 		)
 		(stroke
 			(width 0)
@@ -25945,7 +36451,7 @@
 	)
 	(wire
 		(pts
-			(xy 416.56 346.71) (xy 416.56 351.79)
+			(xy 374.65 372.11) (xy 374.65 377.19)
 		)
 		(stroke
 			(width 0)
@@ -25955,7 +36461,7 @@
 	)
 	(wire
 		(pts
-			(xy 541.02 354.33) (xy 541.02 351.79)
+			(xy 494.03 411.48) (xy 494.03 408.94)
 		)
 		(stroke
 			(width 0)
@@ -25975,7 +36481,7 @@
 	)
 	(wire
 		(pts
-			(xy 447.04 330.2) (xy 447.04 335.28)
+			(xy 405.13 355.6) (xy 405.13 360.68)
 		)
 		(stroke
 			(width 0)
@@ -25985,7 +36491,7 @@
 	)
 	(wire
 		(pts
-			(xy 778.51 316.23) (xy 781.05 316.23)
+			(xy 675.64 316.23) (xy 678.18 316.23)
 		)
 		(stroke
 			(width 0)
@@ -25995,7 +36501,7 @@
 	)
 	(wire
 		(pts
-			(xy 511.81 231.14) (xy 504.19 231.14)
+			(xy 609.6 265.43) (xy 601.98 265.43)
 		)
 		(stroke
 			(width 0)
@@ -26035,7 +36541,7 @@
 	)
 	(wire
 		(pts
-			(xy 553.72 328.93) (xy 551.18 328.93)
+			(xy 506.73 386.08) (xy 504.19 386.08)
 		)
 		(stroke
 			(width 0)
@@ -26045,7 +36551,7 @@
 	)
 	(wire
 		(pts
-			(xy 576.58 410.21) (xy 582.93 410.21)
+			(xy 695.96 398.78) (xy 702.31 398.78)
 		)
 		(stroke
 			(width 0)
@@ -26075,7 +36581,7 @@
 	)
 	(wire
 		(pts
-			(xy 627.38 421.64) (xy 623.57 417.83)
+			(xy 746.76 410.21) (xy 742.95 406.4)
 		)
 		(stroke
 			(width 0)
@@ -26085,7 +36591,7 @@
 	)
 	(wire
 		(pts
-			(xy 576.58 344.17) (xy 576.58 341.63)
+			(xy 529.59 401.32) (xy 529.59 398.78)
 		)
 		(stroke
 			(width 0)
@@ -26145,7 +36651,7 @@
 	)
 	(wire
 		(pts
-			(xy 594.36 246.38) (xy 598.17 246.38)
+			(xy 666.75 246.38) (xy 670.56 246.38)
 		)
 		(stroke
 			(width 0)
@@ -26155,7 +36661,7 @@
 	)
 	(wire
 		(pts
-			(xy 581.66 417.83) (xy 582.93 417.83)
+			(xy 701.04 406.4) (xy 702.31 406.4)
 		)
 		(stroke
 			(width 0)
@@ -26165,7 +36671,7 @@
 	)
 	(wire
 		(pts
-			(xy 711.2 342.9) (xy 702.31 342.9)
+			(xy 641.35 397.51) (xy 632.46 397.51)
 		)
 		(stroke
 			(width 0)
@@ -26205,7 +36711,7 @@
 	)
 	(wire
 		(pts
-			(xy 603.25 316.23) (xy 596.9 316.23)
+			(xy 556.26 373.38) (xy 549.91 373.38)
 		)
 		(stroke
 			(width 0)
@@ -26235,7 +36741,7 @@
 	)
 	(wire
 		(pts
-			(xy 1144.27 339.09) (xy 1132.84 339.09)
+			(xy 1075.69 389.89) (xy 1064.26 389.89)
 		)
 		(stroke
 			(width 0)
@@ -26255,7 +36761,7 @@
 	)
 	(wire
 		(pts
-			(xy 576.58 328.93) (xy 574.04 328.93)
+			(xy 529.59 386.08) (xy 527.05 386.08)
 		)
 		(stroke
 			(width 0)
@@ -26275,7 +36781,7 @@
 	)
 	(wire
 		(pts
-			(xy 789.94 347.98) (xy 796.29 347.98)
+			(xy 687.07 347.98) (xy 693.42 347.98)
 		)
 		(stroke
 			(width 0)
@@ -26285,7 +36791,7 @@
 	)
 	(wire
 		(pts
-			(xy 449.58 326.39) (xy 449.58 328.93)
+			(xy 407.67 351.79) (xy 407.67 354.33)
 		)
 		(stroke
 			(width 0)
@@ -26325,7 +36831,7 @@
 	)
 	(wire
 		(pts
-			(xy 593.09 246.38) (xy 594.36 246.38)
+			(xy 665.48 246.38) (xy 666.75 246.38)
 		)
 		(stroke
 			(width 0)
@@ -26335,7 +36841,7 @@
 	)
 	(wire
 		(pts
-			(xy 1075.69 336.55) (xy 1080.77 336.55)
+			(xy 1007.11 387.35) (xy 1012.19 387.35)
 		)
 		(stroke
 			(width 0)
@@ -26365,7 +36871,7 @@
 	)
 	(wire
 		(pts
-			(xy 657.86 274.32) (xy 652.78 274.32)
+			(xy 730.25 274.32) (xy 725.17 274.32)
 		)
 		(stroke
 			(width 0)
@@ -26385,7 +36891,7 @@
 	)
 	(wire
 		(pts
-			(xy 563.88 341.63) (xy 561.34 341.63)
+			(xy 516.89 398.78) (xy 514.35 398.78)
 		)
 		(stroke
 			(width 0)
@@ -26435,7 +36941,7 @@
 	)
 	(wire
 		(pts
-			(xy 551.18 407.67) (xy 551.18 408.94)
+			(xy 670.56 396.24) (xy 670.56 397.51)
 		)
 		(stroke
 			(width 0)
@@ -26445,7 +36951,7 @@
 	)
 	(wire
 		(pts
-			(xy 485.14 359.41) (xy 485.14 363.22)
+			(xy 443.23 384.81) (xy 443.23 388.62)
 		)
 		(stroke
 			(width 0)
@@ -26515,7 +37021,7 @@
 	)
 	(wire
 		(pts
-			(xy 485.14 359.41) (xy 490.22 359.41)
+			(xy 443.23 384.81) (xy 448.31 384.81)
 		)
 		(stroke
 			(width 0)
@@ -26525,7 +37031,7 @@
 	)
 	(wire
 		(pts
-			(xy 511.81 370.84) (xy 514.35 370.84)
+			(xy 469.9 396.24) (xy 472.44 396.24)
 		)
 		(stroke
 			(width 0)
@@ -26535,7 +37041,7 @@
 	)
 	(wire
 		(pts
-			(xy 581.66 397.51) (xy 581.66 400.05)
+			(xy 701.04 386.08) (xy 701.04 388.62)
 		)
 		(stroke
 			(width 0)
@@ -26545,7 +37051,7 @@
 	)
 	(wire
 		(pts
-			(xy 551.18 193.04) (xy 551.18 191.77)
+			(xy 609.6 210.82) (xy 609.6 209.55)
 		)
 		(stroke
 			(width 0)
@@ -26575,7 +37081,7 @@
 	)
 	(wire
 		(pts
-			(xy 662.94 238.76) (xy 659.13 238.76)
+			(xy 735.33 238.76) (xy 731.52 238.76)
 		)
 		(stroke
 			(width 0)
@@ -26585,7 +37091,7 @@
 	)
 	(wire
 		(pts
-			(xy 509.27 370.84) (xy 511.81 370.84)
+			(xy 467.36 396.24) (xy 469.9 396.24)
 		)
 		(stroke
 			(width 0)
@@ -26605,7 +37111,7 @@
 	)
 	(wire
 		(pts
-			(xy 678.18 246.38) (xy 678.18 257.81)
+			(xy 750.57 246.38) (xy 750.57 257.81)
 		)
 		(stroke
 			(width 0)
@@ -26625,7 +37131,7 @@
 	)
 	(wire
 		(pts
-			(xy 674.37 213.36) (xy 674.37 212.09)
+			(xy 746.76 213.36) (xy 746.76 212.09)
 		)
 		(stroke
 			(width 0)
@@ -26645,7 +37151,7 @@
 	)
 	(wire
 		(pts
-			(xy 488.95 383.54) (xy 480.06 383.54)
+			(xy 447.04 408.94) (xy 438.15 408.94)
 		)
 		(stroke
 			(width 0)
@@ -26655,7 +37161,7 @@
 	)
 	(wire
 		(pts
-			(xy 645.16 170.18) (xy 643.89 170.18)
+			(xy 717.55 170.18) (xy 716.28 170.18)
 		)
 		(stroke
 			(width 0)
@@ -26665,7 +37171,7 @@
 	)
 	(wire
 		(pts
-			(xy 449.58 401.32) (xy 449.58 411.48)
+			(xy 407.67 426.72) (xy 407.67 436.88)
 		)
 		(stroke
 			(width 0)
@@ -26685,7 +37191,7 @@
 	)
 	(wire
 		(pts
-			(xy 449.58 328.93) (xy 449.58 335.28)
+			(xy 407.67 354.33) (xy 407.67 360.68)
 		)
 		(stroke
 			(width 0)
@@ -26735,7 +37241,7 @@
 	)
 	(wire
 		(pts
-			(xy 688.34 238.76) (xy 690.88 238.76)
+			(xy 760.73 238.76) (xy 763.27 238.76)
 		)
 		(stroke
 			(width 0)
@@ -26785,7 +37291,7 @@
 	)
 	(wire
 		(pts
-			(xy 671.83 220.98) (xy 674.37 220.98)
+			(xy 744.22 220.98) (xy 746.76 220.98)
 		)
 		(stroke
 			(width 0)
@@ -26805,7 +37311,7 @@
 	)
 	(wire
 		(pts
-			(xy 624.84 392.43) (xy 623.57 392.43)
+			(xy 744.22 381) (xy 742.95 381)
 		)
 		(stroke
 			(width 0)
@@ -26825,7 +37331,7 @@
 	)
 	(wire
 		(pts
-			(xy 814.07 347.98) (xy 820.42 347.98)
+			(xy 711.2 347.98) (xy 717.55 347.98)
 		)
 		(stroke
 			(width 0)
@@ -26865,7 +37371,7 @@
 	)
 	(wire
 		(pts
-			(xy 970.28 339.09) (xy 982.98 339.09)
+			(xy 901.7 389.89) (xy 914.4 389.89)
 		)
 		(stroke
 			(width 0)
@@ -26875,7 +37381,7 @@
 	)
 	(wire
 		(pts
-			(xy 551.18 316.23) (xy 541.02 316.23)
+			(xy 504.19 373.38) (xy 494.03 373.38)
 		)
 		(stroke
 			(width 0)
@@ -26885,7 +37391,7 @@
 	)
 	(wire
 		(pts
-			(xy 511.81 378.46) (xy 514.35 378.46)
+			(xy 469.9 403.86) (xy 472.44 403.86)
 		)
 		(stroke
 			(width 0)
@@ -26895,7 +37401,7 @@
 	)
 	(wire
 		(pts
-			(xy 511.81 233.68) (xy 514.35 233.68)
+			(xy 609.6 267.97) (xy 612.14 267.97)
 		)
 		(stroke
 			(width 0)
@@ -26915,7 +37421,7 @@
 	)
 	(wire
 		(pts
-			(xy 581.66 400.05) (xy 582.93 400.05)
+			(xy 701.04 388.62) (xy 702.31 388.62)
 		)
 		(stroke
 			(width 0)
@@ -26985,7 +37491,7 @@
 	)
 	(wire
 		(pts
-			(xy 447.04 406.4) (xy 447.04 401.32)
+			(xy 405.13 431.8) (xy 405.13 426.72)
 		)
 		(stroke
 			(width 0)
@@ -26995,7 +37501,7 @@
 	)
 	(wire
 		(pts
-			(xy 467.36 410.21) (xy 467.36 401.32)
+			(xy 425.45 435.61) (xy 425.45 426.72)
 		)
 		(stroke
 			(width 0)
@@ -27015,7 +37521,7 @@
 	)
 	(wire
 		(pts
-			(xy 581.66 402.59) (xy 582.93 402.59)
+			(xy 701.04 391.16) (xy 702.31 391.16)
 		)
 		(stroke
 			(width 0)
@@ -27075,7 +37581,7 @@
 	)
 	(wire
 		(pts
-			(xy 603.25 341.63) (xy 596.9 341.63)
+			(xy 556.26 398.78) (xy 549.91 398.78)
 		)
 		(stroke
 			(width 0)
@@ -27085,7 +37591,7 @@
 	)
 	(wire
 		(pts
-			(xy 1080.77 317.5) (xy 1080.77 321.31)
+			(xy 1012.19 368.3) (xy 1012.19 372.11)
 		)
 		(stroke
 			(width 0)
@@ -27095,7 +37601,7 @@
 	)
 	(wire
 		(pts
-			(xy 624.84 405.13) (xy 624.84 406.4)
+			(xy 744.22 393.7) (xy 744.22 394.97)
 		)
 		(stroke
 			(width 0)
@@ -27105,7 +37611,7 @@
 	)
 	(wire
 		(pts
-			(xy 647.7 421.64) (xy 635 421.64)
+			(xy 767.08 410.21) (xy 754.38 410.21)
 		)
 		(stroke
 			(width 0)
@@ -27115,7 +37621,7 @@
 	)
 	(wire
 		(pts
-			(xy 762 347.98) (xy 778.51 347.98)
+			(xy 659.13 347.98) (xy 675.64 347.98)
 		)
 		(stroke
 			(width 0)
@@ -27145,7 +37651,7 @@
 	)
 	(wire
 		(pts
-			(xy 581.66 191.77) (xy 562.61 191.77)
+			(xy 640.08 209.55) (xy 621.03 209.55)
 		)
 		(stroke
 			(width 0)
@@ -27155,7 +37661,7 @@
 	)
 	(wire
 		(pts
-			(xy 581.66 412.75) (xy 581.66 415.29)
+			(xy 701.04 401.32) (xy 701.04 403.86)
 		)
 		(stroke
 			(width 0)
@@ -27165,7 +37671,7 @@
 	)
 	(wire
 		(pts
-			(xy 551.18 341.63) (xy 541.02 341.63)
+			(xy 504.19 398.78) (xy 494.03 398.78)
 		)
 		(stroke
 			(width 0)
@@ -27205,7 +37711,7 @@
 	)
 	(wire
 		(pts
-			(xy 1151.89 337.82) (xy 1163.32 337.82)
+			(xy 1083.31 388.62) (xy 1094.74 388.62)
 		)
 		(stroke
 			(width 0)
@@ -27275,7 +37781,7 @@
 	)
 	(wire
 		(pts
-			(xy 554.99 393.7) (xy 558.8 393.7)
+			(xy 674.37 382.27) (xy 678.18 382.27)
 		)
 		(stroke
 			(width 0)
@@ -27295,7 +37801,7 @@
 	)
 	(wire
 		(pts
-			(xy 716.28 325.12) (xy 711.2 325.12)
+			(xy 646.43 379.73) (xy 641.35 379.73)
 		)
 		(stroke
 			(width 0)
@@ -27305,7 +37811,7 @@
 	)
 	(wire
 		(pts
-			(xy 633.73 274.32) (xy 633.73 288.29)
+			(xy 706.12 274.32) (xy 706.12 288.29)
 		)
 		(stroke
 			(width 0)
@@ -27325,7 +37831,7 @@
 	)
 	(wire
 		(pts
-			(xy 576.58 341.63) (xy 574.04 341.63)
+			(xy 529.59 398.78) (xy 527.05 398.78)
 		)
 		(stroke
 			(width 0)
@@ -27365,7 +37871,7 @@
 	)
 	(wire
 		(pts
-			(xy 716.28 325.12) (xy 716.28 322.58)
+			(xy 646.43 379.73) (xy 646.43 377.19)
 		)
 		(stroke
 			(width 0)
@@ -27385,7 +37891,7 @@
 	)
 	(wire
 		(pts
-			(xy 539.75 204.47) (xy 539.75 208.28)
+			(xy 598.17 222.25) (xy 598.17 226.06)
 		)
 		(stroke
 			(width 0)
@@ -27415,7 +37921,7 @@
 	)
 	(wire
 		(pts
-			(xy 647.7 424.18) (xy 635 424.18)
+			(xy 767.08 412.75) (xy 754.38 412.75)
 		)
 		(stroke
 			(width 0)
@@ -27425,7 +37931,7 @@
 	)
 	(wire
 		(pts
-			(xy 624.84 406.4) (xy 624.84 407.67)
+			(xy 744.22 394.97) (xy 744.22 396.24)
 		)
 		(stroke
 			(width 0)
@@ -27455,7 +37961,7 @@
 	)
 	(wire
 		(pts
-			(xy 626.11 392.43) (xy 624.84 392.43)
+			(xy 745.49 381) (xy 744.22 381)
 		)
 		(stroke
 			(width 0)
@@ -27565,7 +38071,7 @@
 	)
 	(wire
 		(pts
-			(xy 566.42 316.23) (xy 563.88 316.23)
+			(xy 519.43 373.38) (xy 516.89 373.38)
 		)
 		(stroke
 			(width 0)
@@ -27595,7 +38101,7 @@
 	)
 	(wire
 		(pts
-			(xy 480.06 375.92) (xy 491.49 375.92)
+			(xy 438.15 401.32) (xy 449.58 401.32)
 		)
 		(stroke
 			(width 0)
@@ -27605,7 +38111,7 @@
 	)
 	(wire
 		(pts
-			(xy 688.34 228.6) (xy 688.34 231.14)
+			(xy 760.73 228.6) (xy 760.73 231.14)
 		)
 		(stroke
 			(width 0)
@@ -27615,7 +38121,7 @@
 	)
 	(wire
 		(pts
-			(xy 425.45 346.71) (xy 425.45 351.79)
+			(xy 383.54 372.11) (xy 383.54 377.19)
 		)
 		(stroke
 			(width 0)
@@ -27625,7 +38131,7 @@
 	)
 	(wire
 		(pts
-			(xy 469.9 326.39) (xy 469.9 335.28)
+			(xy 427.99 351.79) (xy 427.99 360.68)
 		)
 		(stroke
 			(width 0)
@@ -27645,7 +38151,7 @@
 	)
 	(wire
 		(pts
-			(xy 623.57 402.59) (xy 626.11 402.59)
+			(xy 742.95 391.16) (xy 745.49 391.16)
 		)
 		(stroke
 			(width 0)
@@ -27655,7 +38161,7 @@
 	)
 	(wire
 		(pts
-			(xy 789.94 316.23) (xy 789.94 318.77)
+			(xy 687.07 316.23) (xy 687.07 318.77)
 		)
 		(stroke
 			(width 0)
@@ -27665,7 +38171,7 @@
 	)
 	(wire
 		(pts
-			(xy 562.61 208.28) (xy 551.18 208.28)
+			(xy 621.03 226.06) (xy 609.6 226.06)
 		)
 		(stroke
 			(width 0)
@@ -27685,7 +38191,7 @@
 	)
 	(wire
 		(pts
-			(xy 651.51 175.26) (xy 651.51 200.66)
+			(xy 723.9 175.26) (xy 723.9 200.66)
 		)
 		(stroke
 			(width 0)
@@ -27705,7 +38211,7 @@
 	)
 	(wire
 		(pts
-			(xy 514.35 233.68) (xy 516.89 233.68)
+			(xy 612.14 267.97) (xy 614.68 267.97)
 		)
 		(stroke
 			(width 0)
@@ -27735,17 +38241,7 @@
 	)
 	(wire
 		(pts
-			(xy 712.47 347.98) (xy 702.31 347.98)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "afe7c0ca-1ac4-4ff8-b2b4-e5ef4dafdc7f")
-	)
-	(wire
-		(pts
-			(xy 416.56 351.79) (xy 416.56 363.22)
+			(xy 374.65 377.19) (xy 374.65 388.62)
 		)
 		(stroke
 			(width 0)
@@ -27815,7 +38311,7 @@
 	)
 	(wire
 		(pts
-			(xy 576.58 410.21) (xy 576.58 411.48)
+			(xy 695.96 398.78) (xy 695.96 400.05)
 		)
 		(stroke
 			(width 0)
@@ -27835,7 +38331,7 @@
 	)
 	(wire
 		(pts
-			(xy 488.95 358.14) (xy 480.06 358.14)
+			(xy 447.04 383.54) (xy 438.15 383.54)
 		)
 		(stroke
 			(width 0)
@@ -27845,7 +38341,7 @@
 	)
 	(wire
 		(pts
-			(xy 562.61 386.08) (xy 571.5 386.08)
+			(xy 681.99 374.65) (xy 690.88 374.65)
 		)
 		(stroke
 			(width 0)
@@ -27855,7 +38351,7 @@
 	)
 	(wire
 		(pts
-			(xy 579.12 341.63) (xy 576.58 341.63)
+			(xy 532.13 398.78) (xy 529.59 398.78)
 		)
 		(stroke
 			(width 0)
@@ -27875,7 +38371,7 @@
 	)
 	(wire
 		(pts
-			(xy 551.18 354.33) (xy 541.02 354.33)
+			(xy 504.19 411.48) (xy 494.03 411.48)
 		)
 		(stroke
 			(width 0)
@@ -27885,7 +38381,7 @@
 	)
 	(wire
 		(pts
-			(xy 702.31 335.28) (xy 723.9 335.28)
+			(xy 632.46 389.89) (xy 654.05 389.89)
 		)
 		(stroke
 			(width 0)
@@ -27895,7 +38391,7 @@
 	)
 	(wire
 		(pts
-			(xy 605.79 236.22) (xy 623.57 236.22)
+			(xy 678.18 236.22) (xy 695.96 236.22)
 		)
 		(stroke
 			(width 0)
@@ -27905,7 +38401,7 @@
 	)
 	(wire
 		(pts
-			(xy 511.81 369.57) (xy 511.81 370.84)
+			(xy 469.9 394.97) (xy 469.9 396.24)
 		)
 		(stroke
 			(width 0)
@@ -27945,7 +38441,7 @@
 	)
 	(wire
 		(pts
-			(xy 1158.24 342.9) (xy 1160.78 342.9)
+			(xy 1089.66 393.7) (xy 1092.2 393.7)
 		)
 		(stroke
 			(width 0)
@@ -27985,7 +38481,7 @@
 	)
 	(wire
 		(pts
-			(xy 551.18 344.17) (xy 551.18 341.63)
+			(xy 504.19 401.32) (xy 504.19 398.78)
 		)
 		(stroke
 			(width 0)
@@ -27995,7 +38491,7 @@
 	)
 	(wire
 		(pts
-			(xy 641.35 284.48) (xy 641.35 274.32)
+			(xy 713.74 284.48) (xy 713.74 274.32)
 		)
 		(stroke
 			(width 0)
@@ -28025,7 +38521,7 @@
 	)
 	(wire
 		(pts
-			(xy 426.72 381) (xy 436.88 381)
+			(xy 384.81 406.4) (xy 394.97 406.4)
 		)
 		(stroke
 			(width 0)
@@ -28045,7 +38541,7 @@
 	)
 	(wire
 		(pts
-			(xy 814.07 337.82) (xy 820.42 337.82)
+			(xy 711.2 337.82) (xy 717.55 337.82)
 		)
 		(stroke
 			(width 0)
@@ -28105,13 +38601,23 @@
 	)
 	(wire
 		(pts
-			(xy 589.28 316.23) (xy 586.74 316.23)
+			(xy 542.29 373.38) (xy 539.75 373.38)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
 		(uuid "bbbc529d-32fb-4fb9-a692-7960e176398e")
+	)
+	(wire
+		(pts
+			(xy 643.89 402.59) (xy 642.62 402.59)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bc0b4fd6-9cf1-40e2-a036-f64b842a98ea")
 	)
 	(wire
 		(pts
@@ -28125,13 +38631,23 @@
 	)
 	(wire
 		(pts
-			(xy 558.8 393.7) (xy 558.8 394.97)
+			(xy 678.18 382.27) (xy 678.18 383.54)
 		)
 		(stroke
 			(width 0)
 			(type default)
 		)
 		(uuid "bd82edba-972b-4dd6-aaec-39c2924b2032")
+	)
+	(wire
+		(pts
+			(xy 566.42 397.51) (xy 581.66 397.51)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bdad831b-33c3-4a0d-8035-18a8b662aac1")
 	)
 	(wire
 		(pts
@@ -28165,7 +38681,7 @@
 	)
 	(wire
 		(pts
-			(xy 1080.77 313.69) (xy 1080.77 317.5)
+			(xy 1012.19 364.49) (xy 1012.19 368.3)
 		)
 		(stroke
 			(width 0)
@@ -28175,7 +38691,7 @@
 	)
 	(wire
 		(pts
-			(xy 685.8 231.14) (xy 688.34 231.14)
+			(xy 758.19 231.14) (xy 760.73 231.14)
 		)
 		(stroke
 			(width 0)
@@ -28225,7 +38741,7 @@
 	)
 	(wire
 		(pts
-			(xy 781.05 316.23) (xy 781.05 318.77)
+			(xy 678.18 316.23) (xy 678.18 318.77)
 		)
 		(stroke
 			(width 0)
@@ -28245,7 +38761,7 @@
 	)
 	(wire
 		(pts
-			(xy 638.81 175.26) (xy 638.81 200.66)
+			(xy 711.2 175.26) (xy 711.2 200.66)
 		)
 		(stroke
 			(width 0)
@@ -28255,7 +38771,7 @@
 	)
 	(wire
 		(pts
-			(xy 781.05 326.39) (xy 781.05 337.82)
+			(xy 678.18 326.39) (xy 678.18 337.82)
 		)
 		(stroke
 			(width 0)
@@ -28275,7 +38791,7 @@
 	)
 	(wire
 		(pts
-			(xy 515.62 220.98) (xy 516.89 220.98)
+			(xy 613.41 255.27) (xy 614.68 255.27)
 		)
 		(stroke
 			(width 0)
@@ -28285,7 +38801,7 @@
 	)
 	(wire
 		(pts
-			(xy 624.84 389.89) (xy 624.84 392.43)
+			(xy 744.22 378.46) (xy 744.22 381)
 		)
 		(stroke
 			(width 0)
@@ -28295,7 +38811,7 @@
 	)
 	(wire
 		(pts
-			(xy 641.35 337.82) (xy 651.51 337.82)
+			(xy 571.5 392.43) (xy 581.66 392.43)
 		)
 		(stroke
 			(width 0)
@@ -28315,17 +38831,7 @@
 	)
 	(wire
 		(pts
-			(xy 636.27 342.9) (xy 651.51 342.9)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "c3a66173-9d94-487c-90ac-75e7101f0ba8")
-	)
-	(wire
-		(pts
-			(xy 828.04 337.82) (xy 834.39 337.82)
+			(xy 725.17 337.82) (xy 731.52 337.82)
 		)
 		(stroke
 			(width 0)
@@ -28345,7 +38851,7 @@
 	)
 	(wire
 		(pts
-			(xy 763.27 312.42) (xy 778.51 312.42)
+			(xy 660.4 312.42) (xy 675.64 312.42)
 		)
 		(stroke
 			(width 0)
@@ -28355,7 +38861,7 @@
 	)
 	(wire
 		(pts
-			(xy 530.86 316.23) (xy 541.02 316.23)
+			(xy 483.87 373.38) (xy 494.03 373.38)
 		)
 		(stroke
 			(width 0)
@@ -28365,7 +38871,7 @@
 	)
 	(wire
 		(pts
-			(xy 566.42 354.33) (xy 563.88 354.33)
+			(xy 519.43 411.48) (xy 516.89 411.48)
 		)
 		(stroke
 			(width 0)
@@ -28415,7 +38921,7 @@
 	)
 	(wire
 		(pts
-			(xy 643.89 168.91) (xy 643.89 170.18)
+			(xy 716.28 168.91) (xy 716.28 170.18)
 		)
 		(stroke
 			(width 0)
@@ -28435,7 +38941,7 @@
 	)
 	(wire
 		(pts
-			(xy 581.66 415.29) (xy 582.93 415.29)
+			(xy 701.04 403.86) (xy 702.31 403.86)
 		)
 		(stroke
 			(width 0)
@@ -28465,7 +38971,7 @@
 	)
 	(wire
 		(pts
-			(xy 589.28 341.63) (xy 586.74 341.63)
+			(xy 542.29 398.78) (xy 539.75 398.78)
 		)
 		(stroke
 			(width 0)
@@ -28485,7 +38991,7 @@
 	)
 	(wire
 		(pts
-			(xy 911.86 331.47) (xy 913.13 331.47)
+			(xy 843.28 382.27) (xy 844.55 382.27)
 		)
 		(stroke
 			(width 0)
@@ -28505,7 +39011,7 @@
 	)
 	(wire
 		(pts
-			(xy 448.31 411.48) (xy 449.58 411.48)
+			(xy 406.4 436.88) (xy 407.67 436.88)
 		)
 		(stroke
 			(width 0)
@@ -28545,7 +39051,7 @@
 	)
 	(wire
 		(pts
-			(xy 641.35 172.72) (xy 641.35 200.66)
+			(xy 713.74 172.72) (xy 713.74 200.66)
 		)
 		(stroke
 			(width 0)
@@ -28575,7 +39081,7 @@
 	)
 	(wire
 		(pts
-			(xy 519.43 191.77) (xy 539.75 191.77)
+			(xy 577.85 209.55) (xy 598.17 209.55)
 		)
 		(stroke
 			(width 0)
@@ -28595,7 +39101,7 @@
 	)
 	(wire
 		(pts
-			(xy 598.17 246.38) (xy 623.57 246.38)
+			(xy 670.56 246.38) (xy 695.96 246.38)
 		)
 		(stroke
 			(width 0)
@@ -28605,7 +39111,7 @@
 	)
 	(wire
 		(pts
-			(xy 659.13 212.09) (xy 674.37 212.09)
+			(xy 731.52 212.09) (xy 746.76 212.09)
 		)
 		(stroke
 			(width 0)
@@ -28625,7 +39131,7 @@
 	)
 	(wire
 		(pts
-			(xy 640.08 325.12) (xy 640.08 327.66)
+			(xy 570.23 379.73) (xy 570.23 382.27)
 		)
 		(stroke
 			(width 0)
@@ -28685,7 +39191,7 @@
 	)
 	(wire
 		(pts
-			(xy 435.61 375.92) (xy 436.88 375.92)
+			(xy 393.7 401.32) (xy 394.97 401.32)
 		)
 		(stroke
 			(width 0)
@@ -28715,7 +39221,7 @@
 	)
 	(wire
 		(pts
-			(xy 457.2 410.21) (xy 457.2 401.32)
+			(xy 415.29 435.61) (xy 415.29 426.72)
 		)
 		(stroke
 			(width 0)
@@ -28745,7 +39251,7 @@
 	)
 	(wire
 		(pts
-			(xy 488.95 381) (xy 480.06 381)
+			(xy 447.04 406.4) (xy 438.15 406.4)
 		)
 		(stroke
 			(width 0)
@@ -28775,7 +39281,7 @@
 	)
 	(wire
 		(pts
-			(xy 662.94 228.6) (xy 688.34 228.6)
+			(xy 735.33 228.6) (xy 760.73 228.6)
 		)
 		(stroke
 			(width 0)
@@ -28805,7 +39311,7 @@
 	)
 	(wire
 		(pts
-			(xy 563.88 316.23) (xy 561.34 316.23)
+			(xy 516.89 373.38) (xy 514.35 373.38)
 		)
 		(stroke
 			(width 0)
@@ -28815,7 +39321,7 @@
 	)
 	(wire
 		(pts
-			(xy 539.75 191.77) (xy 539.75 196.85)
+			(xy 598.17 209.55) (xy 598.17 214.63)
 		)
 		(stroke
 			(width 0)
@@ -28825,7 +39331,7 @@
 	)
 	(wire
 		(pts
-			(xy 631.19 193.04) (xy 633.73 193.04)
+			(xy 703.58 193.04) (xy 706.12 193.04)
 		)
 		(stroke
 			(width 0)
@@ -28875,7 +39381,7 @@
 	)
 	(wire
 		(pts
-			(xy 652.78 274.32) (xy 648.97 274.32)
+			(xy 725.17 274.32) (xy 721.36 274.32)
 		)
 		(stroke
 			(width 0)
@@ -28895,7 +39401,7 @@
 	)
 	(wire
 		(pts
-			(xy 789.94 345.44) (xy 789.94 347.98)
+			(xy 687.07 345.44) (xy 687.07 347.98)
 		)
 		(stroke
 			(width 0)
@@ -28905,7 +39411,7 @@
 	)
 	(wire
 		(pts
-			(xy 454.66 416.56) (xy 454.66 401.32)
+			(xy 412.75 441.96) (xy 412.75 426.72)
 		)
 		(stroke
 			(width 0)
@@ -28935,7 +39441,7 @@
 	)
 	(wire
 		(pts
-			(xy 789.94 337.82) (xy 796.29 337.82)
+			(xy 687.07 337.82) (xy 693.42 337.82)
 		)
 		(stroke
 			(width 0)
@@ -28955,7 +39461,7 @@
 	)
 	(wire
 		(pts
-			(xy 702.31 327.66) (xy 712.47 327.66)
+			(xy 632.46 382.27) (xy 642.62 382.27)
 		)
 		(stroke
 			(width 0)
@@ -28965,7 +39471,7 @@
 	)
 	(wire
 		(pts
-			(xy 859.79 337.82) (xy 848.36 337.82)
+			(xy 756.92 337.82) (xy 745.49 337.82)
 		)
 		(stroke
 			(width 0)
@@ -28975,7 +39481,7 @@
 	)
 	(wire
 		(pts
-			(xy 702.31 330.2) (xy 712.47 330.2)
+			(xy 632.46 384.81) (xy 642.62 384.81)
 		)
 		(stroke
 			(width 0)
@@ -28985,7 +39491,7 @@
 	)
 	(wire
 		(pts
-			(xy 778.51 309.88) (xy 778.51 312.42)
+			(xy 675.64 309.88) (xy 675.64 312.42)
 		)
 		(stroke
 			(width 0)
@@ -28995,7 +39501,7 @@
 	)
 	(wire
 		(pts
-			(xy 579.12 328.93) (xy 576.58 328.93)
+			(xy 532.13 386.08) (xy 529.59 386.08)
 		)
 		(stroke
 			(width 0)
@@ -29025,7 +39531,7 @@
 	)
 	(wire
 		(pts
-			(xy 416.56 365.76) (xy 436.88 365.76)
+			(xy 374.65 391.16) (xy 394.97 391.16)
 		)
 		(stroke
 			(width 0)
@@ -29065,7 +39571,7 @@
 	)
 	(wire
 		(pts
-			(xy 436.88 335.28) (xy 444.5 335.28)
+			(xy 394.97 360.68) (xy 402.59 360.68)
 		)
 		(stroke
 			(width 0)
@@ -29075,7 +39581,7 @@
 	)
 	(wire
 		(pts
-			(xy 541.02 318.77) (xy 541.02 316.23)
+			(xy 494.03 375.92) (xy 494.03 373.38)
 		)
 		(stroke
 			(width 0)
@@ -29085,7 +39591,7 @@
 	)
 	(wire
 		(pts
-			(xy 624.84 407.67) (xy 624.84 410.21)
+			(xy 744.22 396.24) (xy 744.22 398.78)
 		)
 		(stroke
 			(width 0)
@@ -29095,7 +39601,7 @@
 	)
 	(wire
 		(pts
-			(xy 553.72 341.63) (xy 551.18 341.63)
+			(xy 506.73 398.78) (xy 504.19 398.78)
 		)
 		(stroke
 			(width 0)
@@ -29115,7 +39621,7 @@
 	)
 	(wire
 		(pts
-			(xy 1088.39 339.09) (xy 1094.74 339.09)
+			(xy 1019.81 389.89) (xy 1026.16 389.89)
 		)
 		(stroke
 			(width 0)
@@ -29135,7 +39641,7 @@
 	)
 	(wire
 		(pts
-			(xy 482.6 370.84) (xy 509.27 370.84)
+			(xy 440.69 396.24) (xy 467.36 396.24)
 		)
 		(stroke
 			(width 0)
@@ -29155,7 +39661,7 @@
 	)
 	(wire
 		(pts
-			(xy 674.37 220.98) (xy 676.91 220.98)
+			(xy 746.76 220.98) (xy 749.3 220.98)
 		)
 		(stroke
 			(width 0)
@@ -29165,7 +39671,7 @@
 	)
 	(wire
 		(pts
-			(xy 703.58 340.36) (xy 702.31 340.36)
+			(xy 633.73 394.97) (xy 632.46 394.97)
 		)
 		(stroke
 			(width 0)
@@ -29175,7 +39681,7 @@
 	)
 	(wire
 		(pts
-			(xy 688.34 231.14) (xy 690.88 231.14)
+			(xy 760.73 231.14) (xy 763.27 231.14)
 		)
 		(stroke
 			(width 0)
@@ -29185,7 +39691,7 @@
 	)
 	(wire
 		(pts
-			(xy 469.9 410.21) (xy 469.9 401.32)
+			(xy 427.99 435.61) (xy 427.99 426.72)
 		)
 		(stroke
 			(width 0)
@@ -29195,7 +39701,7 @@
 	)
 	(wire
 		(pts
-			(xy 436.88 370.84) (xy 436.88 369.57)
+			(xy 394.97 396.24) (xy 394.97 394.97)
 		)
 		(stroke
 			(width 0)
@@ -29235,7 +39741,7 @@
 	)
 	(wire
 		(pts
-			(xy 563.88 354.33) (xy 561.34 354.33)
+			(xy 516.89 411.48) (xy 514.35 411.48)
 		)
 		(stroke
 			(width 0)
@@ -29245,7 +39751,7 @@
 	)
 	(wire
 		(pts
-			(xy 702.31 322.58) (xy 716.28 322.58)
+			(xy 632.46 377.19) (xy 646.43 377.19)
 		)
 		(stroke
 			(width 0)
@@ -29255,7 +39761,7 @@
 	)
 	(wire
 		(pts
-			(xy 623.57 420.37) (xy 627.38 424.18)
+			(xy 742.95 408.94) (xy 746.76 412.75)
 		)
 		(stroke
 			(width 0)
@@ -29265,7 +39771,7 @@
 	)
 	(wire
 		(pts
-			(xy 472.44 326.39) (xy 472.44 335.28)
+			(xy 430.53 351.79) (xy 430.53 360.68)
 		)
 		(stroke
 			(width 0)
@@ -29275,7 +39781,7 @@
 	)
 	(wire
 		(pts
-			(xy 589.28 328.93) (xy 586.74 328.93)
+			(xy 542.29 386.08) (xy 539.75 386.08)
 		)
 		(stroke
 			(width 0)
@@ -29295,7 +39801,7 @@
 	)
 	(wire
 		(pts
-			(xy 635 342.9) (xy 636.27 342.9)
+			(xy 565.15 397.51) (xy 566.42 397.51)
 		)
 		(stroke
 			(width 0)
@@ -29305,7 +39811,7 @@
 	)
 	(wire
 		(pts
-			(xy 1093.47 317.5) (xy 1096.01 317.5)
+			(xy 1024.89 368.3) (xy 1027.43 368.3)
 		)
 		(stroke
 			(width 0)
@@ -29315,7 +39821,7 @@
 	)
 	(wire
 		(pts
-			(xy 623.57 389.89) (xy 624.84 389.89)
+			(xy 742.95 378.46) (xy 744.22 378.46)
 		)
 		(stroke
 			(width 0)
@@ -29325,7 +39831,7 @@
 	)
 	(wire
 		(pts
-			(xy 652.78 280.67) (xy 652.78 281.94)
+			(xy 725.17 280.67) (xy 725.17 281.94)
 		)
 		(stroke
 			(width 0)
@@ -29365,7 +39871,7 @@
 	)
 	(wire
 		(pts
-			(xy 464.82 410.21) (xy 464.82 401.32)
+			(xy 422.91 435.61) (xy 422.91 426.72)
 		)
 		(stroke
 			(width 0)
@@ -29385,7 +39891,7 @@
 	)
 	(wire
 		(pts
-			(xy 462.28 326.39) (xy 462.28 335.28)
+			(xy 420.37 351.79) (xy 420.37 360.68)
 		)
 		(stroke
 			(width 0)
@@ -29395,7 +39901,7 @@
 	)
 	(wire
 		(pts
-			(xy 643.89 284.48) (xy 643.89 274.32)
+			(xy 716.28 284.48) (xy 716.28 274.32)
 		)
 		(stroke
 			(width 0)
@@ -29465,7 +39971,7 @@
 	)
 	(wire
 		(pts
-			(xy 524.51 233.68) (xy 574.04 233.68)
+			(xy 622.3 267.97) (xy 650.24 267.97)
 		)
 		(stroke
 			(width 0)
@@ -29485,7 +39991,7 @@
 	)
 	(wire
 		(pts
-			(xy 551.18 400.05) (xy 554.99 400.05)
+			(xy 670.56 388.62) (xy 674.37 388.62)
 		)
 		(stroke
 			(width 0)
@@ -29495,7 +40001,7 @@
 	)
 	(wire
 		(pts
-			(xy 589.28 354.33) (xy 586.74 354.33)
+			(xy 542.29 411.48) (xy 539.75 411.48)
 		)
 		(stroke
 			(width 0)
@@ -29525,6 +40031,16 @@
 	)
 	(wire
 		(pts
+			(xy 632.46 402.59) (xy 642.62 402.59)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e512f9f0-a59a-41a5-aa80-63d57f9e6148")
+	)
+	(wire
+		(pts
 			(xy 231.14 674.37) (xy 229.87 674.37)
 		)
 		(stroke
@@ -29545,7 +40061,7 @@
 	)
 	(wire
 		(pts
-			(xy 778.51 347.98) (xy 789.94 347.98)
+			(xy 675.64 347.98) (xy 687.07 347.98)
 		)
 		(stroke
 			(width 0)
@@ -29585,7 +40101,7 @@
 	)
 	(wire
 		(pts
-			(xy 605.79 238.76) (xy 623.57 238.76)
+			(xy 678.18 238.76) (xy 695.96 238.76)
 		)
 		(stroke
 			(width 0)
@@ -29595,7 +40111,7 @@
 	)
 	(wire
 		(pts
-			(xy 796.29 337.82) (xy 800.1 337.82)
+			(xy 693.42 337.82) (xy 697.23 337.82)
 		)
 		(stroke
 			(width 0)
@@ -29605,7 +40121,7 @@
 	)
 	(wire
 		(pts
-			(xy 551.18 207.01) (xy 551.18 208.28)
+			(xy 609.6 224.79) (xy 609.6 226.06)
 		)
 		(stroke
 			(width 0)
@@ -29625,7 +40141,7 @@
 	)
 	(wire
 		(pts
-			(xy 781.05 316.23) (xy 789.94 316.23)
+			(xy 678.18 316.23) (xy 687.07 316.23)
 		)
 		(stroke
 			(width 0)
@@ -29655,7 +40171,7 @@
 	)
 	(wire
 		(pts
-			(xy 623.57 410.21) (xy 624.84 410.21)
+			(xy 742.95 398.78) (xy 744.22 398.78)
 		)
 		(stroke
 			(width 0)
@@ -29685,7 +40201,7 @@
 	)
 	(wire
 		(pts
-			(xy 553.72 316.23) (xy 551.18 316.23)
+			(xy 506.73 373.38) (xy 504.19 373.38)
 		)
 		(stroke
 			(width 0)
@@ -29705,7 +40221,7 @@
 	)
 	(wire
 		(pts
-			(xy 415.29 346.71) (xy 416.56 346.71)
+			(xy 373.38 372.11) (xy 374.65 372.11)
 		)
 		(stroke
 			(width 0)
@@ -29715,7 +40231,7 @@
 	)
 	(wire
 		(pts
-			(xy 603.25 328.93) (xy 596.9 328.93)
+			(xy 556.26 386.08) (xy 549.91 386.08)
 		)
 		(stroke
 			(width 0)
@@ -29735,7 +40251,7 @@
 	)
 	(wire
 		(pts
-			(xy 581.66 415.29) (xy 581.66 417.83)
+			(xy 701.04 403.86) (xy 701.04 406.4)
 		)
 		(stroke
 			(width 0)
@@ -29795,7 +40311,7 @@
 	)
 	(wire
 		(pts
-			(xy 581.66 412.75) (xy 582.93 412.75)
+			(xy 701.04 401.32) (xy 702.31 401.32)
 		)
 		(stroke
 			(width 0)
@@ -29805,7 +40321,7 @@
 	)
 	(wire
 		(pts
-			(xy 949.96 331.47) (xy 962.66 331.47)
+			(xy 881.38 382.27) (xy 894.08 382.27)
 		)
 		(stroke
 			(width 0)
@@ -29815,7 +40331,7 @@
 	)
 	(wire
 		(pts
-			(xy 671.83 213.36) (xy 674.37 213.36)
+			(xy 744.22 213.36) (xy 746.76 213.36)
 		)
 		(stroke
 			(width 0)
@@ -29845,7 +40361,7 @@
 	)
 	(wire
 		(pts
-			(xy 551.18 328.93) (xy 551.18 326.39)
+			(xy 504.19 386.08) (xy 504.19 383.54)
 		)
 		(stroke
 			(width 0)
@@ -29875,7 +40391,7 @@
 	)
 	(wire
 		(pts
-			(xy 579.12 316.23) (xy 576.58 316.23)
+			(xy 532.13 373.38) (xy 529.59 373.38)
 		)
 		(stroke
 			(width 0)
@@ -29985,7 +40501,7 @@
 	)
 	(wire
 		(pts
-			(xy 920.75 331.47) (xy 924.56 331.47)
+			(xy 852.17 382.27) (xy 855.98 382.27)
 		)
 		(stroke
 			(width 0)
@@ -30015,7 +40531,7 @@
 	)
 	(wire
 		(pts
-			(xy 576.58 328.93) (xy 576.58 326.39)
+			(xy 529.59 386.08) (xy 529.59 383.54)
 		)
 		(stroke
 			(width 0)
@@ -30025,7 +40541,7 @@
 	)
 	(wire
 		(pts
-			(xy 807.72 347.98) (xy 814.07 347.98)
+			(xy 704.85 347.98) (xy 711.2 347.98)
 		)
 		(stroke
 			(width 0)
@@ -30045,7 +40561,7 @@
 	)
 	(wire
 		(pts
-			(xy 416.56 373.38) (xy 436.88 373.38)
+			(xy 374.65 398.78) (xy 394.97 398.78)
 		)
 		(stroke
 			(width 0)
@@ -30075,7 +40591,7 @@
 	)
 	(wire
 		(pts
-			(xy 566.42 341.63) (xy 563.88 341.63)
+			(xy 519.43 398.78) (xy 516.89 398.78)
 		)
 		(stroke
 			(width 0)
@@ -30105,7 +40621,7 @@
 	)
 	(wire
 		(pts
-			(xy 1033.78 339.09) (xy 1040.13 339.09)
+			(xy 965.2 389.89) (xy 971.55 389.89)
 		)
 		(stroke
 			(width 0)
@@ -30115,7 +40631,7 @@
 	)
 	(wire
 		(pts
-			(xy 911.86 331.47) (xy 900.43 331.47)
+			(xy 843.28 382.27) (xy 831.85 382.27)
 		)
 		(stroke
 			(width 0)
@@ -30125,7 +40641,7 @@
 	)
 	(wire
 		(pts
-			(xy 778.51 312.42) (xy 778.51 316.23)
+			(xy 675.64 312.42) (xy 675.64 316.23)
 		)
 		(stroke
 			(width 0)
@@ -30135,7 +40651,7 @@
 	)
 	(wire
 		(pts
-			(xy 444.5 401.32) (xy 444.5 403.86)
+			(xy 402.59 426.72) (xy 402.59 429.26)
 		)
 		(stroke
 			(width 0)
@@ -30155,7 +40671,7 @@
 	)
 	(wire
 		(pts
-			(xy 624.84 407.67) (xy 623.57 407.67)
+			(xy 744.22 396.24) (xy 742.95 396.24)
 		)
 		(stroke
 			(width 0)
@@ -30175,7 +40691,7 @@
 	)
 	(wire
 		(pts
-			(xy 703.58 325.12) (xy 702.31 325.12)
+			(xy 633.73 379.73) (xy 632.46 379.73)
 		)
 		(stroke
 			(width 0)
@@ -30225,7 +40741,7 @@
 	)
 	(wire
 		(pts
-			(xy 1028.7 339.09) (xy 1021.08 339.09)
+			(xy 960.12 389.89) (xy 952.5 389.89)
 		)
 		(stroke
 			(width 0)
@@ -30275,7 +40791,7 @@
 	)
 	(wire
 		(pts
-			(xy 554.99 386.08) (xy 558.8 386.08)
+			(xy 674.37 374.65) (xy 678.18 374.65)
 		)
 		(stroke
 			(width 0)
@@ -30285,7 +40801,7 @@
 	)
 	(wire
 		(pts
-			(xy 547.37 407.67) (xy 551.18 407.67)
+			(xy 666.75 396.24) (xy 670.56 396.24)
 		)
 		(stroke
 			(width 0)
@@ -30305,7 +40821,7 @@
 	)
 	(wire
 		(pts
-			(xy 576.58 407.67) (xy 582.93 407.67)
+			(xy 695.96 396.24) (xy 702.31 396.24)
 		)
 		(stroke
 			(width 0)
@@ -30335,7 +40851,7 @@
 	)
 	(wire
 		(pts
-			(xy 624.84 392.43) (xy 624.84 394.97)
+			(xy 744.22 381) (xy 744.22 383.54)
 		)
 		(stroke
 			(width 0)
@@ -30345,7 +40861,7 @@
 	)
 	(wire
 		(pts
-			(xy 434.34 403.86) (xy 444.5 403.86)
+			(xy 392.43 429.26) (xy 402.59 429.26)
 		)
 		(stroke
 			(width 0)
@@ -30375,7 +40891,7 @@
 	)
 	(wire
 		(pts
-			(xy 551.18 407.67) (xy 554.99 407.67)
+			(xy 670.56 396.24) (xy 674.37 396.24)
 		)
 		(stroke
 			(width 0)
@@ -30385,7 +40901,7 @@
 	)
 	(wire
 		(pts
-			(xy 911.86 359.41) (xy 913.13 359.41)
+			(xy 843.28 410.21) (xy 844.55 410.21)
 		)
 		(stroke
 			(width 0)
@@ -37332,7 +47848,7 @@
 		)
 	)
 	(image
-		(at 781.05 209.55)
+		(at 839.47 213.36)
 		(scale 0.279565)
 		(uuid "8186668a-d731-419d-9b0f-f1aa92ecd64e")
 		(data "iVBORw0KGgoAAAANSUhEUgAAB6AAAAaqCAYAAABgv2TyAAAMTGlDQ1BJQ0MgUHJvZmlsZQAASImV"
@@ -54118,7 +64634,7 @@
 		)
 	)
 	(label "D3B_ADC"
-		(at 469.9 410.21 90)
+		(at 427.99 435.61 90)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -54128,7 +64644,7 @@
 		(uuid "004ecb03-d23a-4268-ac56-a7b1ca56b172")
 	)
 	(label "Q+ADC_IN"
-		(at 426.72 381 0)
+		(at 384.81 406.4 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -54148,7 +64664,7 @@
 		(uuid "043104c3-d0ba-462f-a00b-ca663f3761f7")
 	)
 	(label "IOUT-"
-		(at 645.16 353.06 0)
+		(at 575.31 407.67 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -54168,7 +64684,7 @@
 		(uuid "046830bd-10b8-4e23-975f-19ba1a82aadf")
 	)
 	(label "D8B_ADC"
-		(at 457.2 410.21 90)
+		(at 415.29 435.61 90)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -54228,7 +64744,7 @@
 		(uuid "0cf4f66f-62ca-44ec-9f0f-7f5e5e2d9058")
 	)
 	(label "D7A_ADC"
-		(at 459.74 326.39 270)
+		(at 417.83 351.79 270)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -54238,7 +64754,7 @@
 		(uuid "0cfbf39f-d279-4d36-a016-cf0e7fe1b678")
 	)
 	(label "VTUNE_ADF4351_LO"
-		(at 683.26 243.84 180)
+		(at 755.65 243.84 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -54378,7 +64894,7 @@
 		(uuid "2340fd27-d077-47bf-8151-448efb575451")
 	)
 	(label "D8A_ADC"
-		(at 457.2 326.39 270)
+		(at 415.29 351.79 270)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -54438,7 +64954,7 @@
 		(uuid "2aadcc26-ce38-41af-8594-47249a7d3c3d")
 	)
 	(label "IOUT+"
-		(at 603.25 328.93 180)
+		(at 556.26 386.08 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -54478,7 +64994,7 @@
 		(uuid "2d839ff3-b8d7-46c6-ba60-95d2a8bf5402")
 	)
 	(label "D9A_ADC_MSB"
-		(at 454.66 320.04 270)
+		(at 412.75 345.44 270)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -54488,7 +65004,7 @@
 		(uuid "302e4f5d-a214-4543-bd1d-cdf76d66d4cc")
 	)
 	(label "VTUNE_ADF4351_LO"
-		(at 581.66 191.77 180)
+		(at 640.08 209.55 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -54558,7 +65074,7 @@
 		(uuid "39667750-4447-493d-9416-36bd6843a339")
 	)
 	(label "LO_A_OUT-"
-		(at 641.35 284.48 90)
+		(at 713.74 284.48 90)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -54588,7 +65104,7 @@
 		(uuid "3c7013ff-a5ea-45b7-9471-7f24fb855d63")
 	)
 	(label "LD_ADF4351_LO"
-		(at 651.51 175.26 270)
+		(at 723.9 175.26 270)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -54688,7 +65204,7 @@
 		(uuid "466c7e44-c161-47a0-ad33-24e5fa3026c0")
 	)
 	(label "IOUT+"
-		(at 708.66 350.52 180)
+		(at 638.81 405.13 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -54768,7 +65284,7 @@
 		(uuid "49dec89f-dbbc-4fcd-b726-87dbdf6274d7")
 	)
 	(label "D0A_ADC"
-		(at 488.95 358.14 180)
+		(at 447.04 383.54 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -54778,7 +65294,7 @@
 		(uuid "4a4d47a1-1882-4a4c-90b7-24406be4db27")
 	)
 	(label "CPOUT_ADF4351_LO"
-		(at 519.43 191.77 0)
+		(at 577.85 209.55 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -54788,7 +65304,7 @@
 		(uuid "4db0f5d0-94cf-40c6-9226-812edec61b52")
 	)
 	(label "I+ADC_IN"
-		(at 427.99 358.14 0)
+		(at 386.08 383.54 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -54818,7 +65334,7 @@
 		(uuid "4f4482c9-261a-4b3b-9cff-4ec28f34b977")
 	)
 	(label "DATA_ADF4351_LO"
-		(at 605.79 236.22 0)
+		(at 678.18 236.22 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -54858,7 +65374,7 @@
 		(uuid "52769436-cc45-4799-80cb-3aee3132f9c1")
 	)
 	(label "D5B_ADC"
-		(at 464.82 410.21 90)
+		(at 422.91 435.61 90)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -54878,7 +65394,7 @@
 		(uuid "54859d32-65f1-4f31-91c8-fe12e55fe5c6")
 	)
 	(label "LE_ADF4351_LO"
-		(at 605.79 238.76 0)
+		(at 678.18 238.76 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -54908,7 +65424,7 @@
 		(uuid "54ba639e-9d7f-4c0a-9449-665bfc373f6d")
 	)
 	(label "LNA_OUT"
-		(at 1033.78 339.09 0)
+		(at 965.2 389.89 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -54948,7 +65464,7 @@
 		(uuid "5a0248cf-1940-4a9a-834f-1d1aee97be06")
 	)
 	(label "CE_ADF4351_LO"
-		(at 605.79 241.3 0)
+		(at 678.18 241.3 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -54978,7 +65494,7 @@
 		(uuid "5cf4acde-6b5c-426d-9c66-9d251de53938")
 	)
 	(label "I-ADC_IN"
-		(at 427.99 360.68 0)
+		(at 386.08 386.08 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -54998,7 +65514,7 @@
 		(uuid "5f8882e3-bda9-4e6e-b288-a8c496e20097")
 	)
 	(label "IOUT-"
-		(at 603.25 316.23 180)
+		(at 556.26 373.38 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -55028,7 +65544,7 @@
 		(uuid "642280c3-8568-4903-bd99-d7af6509ad12")
 	)
 	(label "QOUT+"
-		(at 641.35 340.36 0)
+		(at 571.5 394.97 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -55078,7 +65594,7 @@
 		(uuid "67a47c5c-94b5-4c36-ab6f-9c491c0bb2e4")
 	)
 	(label "DEMOD_RF_IN"
-		(at 970.28 339.09 0)
+		(at 901.7 389.89 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -55098,7 +65614,7 @@
 		(uuid "69e59ace-350b-409a-9519-f41d74493d70")
 	)
 	(label "Q-ADC_IN"
-		(at 530.86 341.63 0)
+		(at 483.87 398.78 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -55128,7 +65644,7 @@
 		(uuid "6f5c2815-4751-4c74-9766-7703c0ae3771")
 	)
 	(label "DEMOD_RF_IN"
-		(at 949.96 331.47 0)
+		(at 881.38 382.27 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -55138,7 +65654,7 @@
 		(uuid "728eb65a-92e7-4e65-9d21-acd8c40fb33a")
 	)
 	(label "LOIP_demod"
-		(at 563.88 406.4 0)
+		(at 683.26 394.97 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -55178,7 +65694,7 @@
 		(uuid "77ac1bb3-ffef-4160-b733-64466f2f6bb3")
 	)
 	(label "PDBRF_ADF4351_LO"
-		(at 648.97 175.26 270)
+		(at 721.36 175.26 270)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -55228,7 +65744,7 @@
 		(uuid "7d8f5678-4ee8-4362-95e0-e636f3d3aabd")
 	)
 	(label "LOIN_demod"
-		(at 859.79 347.98 180)
+		(at 756.92 347.98 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -55238,7 +65754,7 @@
 		(uuid "7e23a16b-9950-4e70-a398-e71d1f72215e")
 	)
 	(label "Q+ADC_IN"
-		(at 530.86 354.33 0)
+		(at 483.87 411.48 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -55248,7 +65764,7 @@
 		(uuid "7e6b737e-3159-4645-861b-59131fce5221")
 	)
 	(label "D4A_ADC"
-		(at 467.36 326.39 270)
+		(at 425.45 351.79 270)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -55256,16 +65772,6 @@
 			(justify right bottom)
 		)
 		(uuid "7efd8d32-93ea-484d-aefc-b0c001177c04")
-	)
-	(label "ADC_Vocm"
-		(at 641.35 342.9 0)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify left bottom)
-		)
-		(uuid "8019d57e-a9f2-47e8-9d90-5b6ef27760f0")
 	)
 	(label "USB_D-"
 		(at 91.44 622.3 180)
@@ -55278,7 +65784,7 @@
 		(uuid "8090ecd6-4455-4ab1-83d0-8064894d1721")
 	)
 	(label "DEMOD_IN1+"
-		(at 640.08 325.12 0)
+		(at 570.23 379.73 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -55318,7 +65824,7 @@
 		(uuid "84d850e2-30d0-46ab-8b22-764ca64045c5")
 	)
 	(label "SMA_RX_OUT"
-		(at 1151.89 337.82 0)
+		(at 1083.31 388.62 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -55338,7 +65844,7 @@
 		(uuid "88e7d6d5-fa90-4969-9cfe-ec9e69acd715")
 	)
 	(label "LO_B_OUT-"
-		(at 646.43 284.48 90)
+		(at 718.82 284.48 90)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -55348,7 +65854,7 @@
 		(uuid "892e3f80-c812-449f-a52d-d096952e0154")
 	)
 	(label "I+ADC_IN"
-		(at 530.86 328.93 0)
+		(at 483.87 386.08 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -55368,7 +65874,7 @@
 		(uuid "8b2fd9b5-cd7e-494e-88cc-13ea9afadced")
 	)
 	(label "DEMOD_IN1-"
-		(at 645.16 415.29 180)
+		(at 764.54 403.86 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -55388,7 +65894,7 @@
 		(uuid "8b72269a-b055-45f2-a013-71ac4de5cda3")
 	)
 	(label "MUXOUT_ADF4351_LO"
-		(at 638.81 175.26 270)
+		(at 711.2 175.26 270)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -55408,7 +65914,7 @@
 		(uuid "901dd2dd-e5a8-4976-8577-521351c893ec")
 	)
 	(label "D6A_ADC"
-		(at 462.28 326.39 270)
+		(at 420.37 351.79 270)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -55438,7 +65944,7 @@
 		(uuid "91c95fa5-2340-4304-8bec-e95261fee8bb")
 	)
 	(label "REFIN_ADF4351_OSCILLATOR"
-		(at 641.35 172.72 270)
+		(at 713.74 172.72 270)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -55446,16 +65952,6 @@
 			(justify right bottom)
 		)
 		(uuid "92dad52a-1717-4bc8-97ed-eb76da7a3625")
-	)
-	(label "ADC_Vocm"
-		(at 712.47 347.98 180)
-		(effects
-			(font
-				(size 1.27 1.27)
-			)
-			(justify right bottom)
-		)
-		(uuid "930c4c9f-7710-4931-a9bd-624fc284fac3")
 	)
 	(label "DAC_DB2-P2"
 		(at 209.55 135.89 0)
@@ -55468,7 +65964,7 @@
 		(uuid "93ef89c6-bd63-4f44-b339-3a152eac092b")
 	)
 	(label "QOUT+"
-		(at 603.25 354.33 180)
+		(at 556.26 411.48 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -55498,7 +65994,7 @@
 		(uuid "94d3b82e-d270-4c28-baab-b9b1e27a50ea")
 	)
 	(label "QOUT-"
-		(at 603.25 341.63 180)
+		(at 556.26 398.78 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -55508,7 +66004,7 @@
 		(uuid "94e42735-f28f-49de-8902-a9f84b5cec78")
 	)
 	(label "D3A_ADC"
-		(at 469.9 326.39 270)
+		(at 427.99 351.79 270)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -55548,7 +66044,7 @@
 		(uuid "9ca629ef-9fc3-485c-85d9-3783d3d8925c")
 	)
 	(label "DEMOD_IN1-"
-		(at 716.28 322.58 180)
+		(at 646.43 377.19 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -55618,7 +66114,7 @@
 		(uuid "ab2a277b-0854-41d9-8380-d7c231d4af40")
 	)
 	(label "D5A_ADC"
-		(at 464.82 326.39 270)
+		(at 422.91 351.79 270)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -55638,7 +66134,7 @@
 		(uuid "ac16bc90-cd09-47ac-b68e-ef77b82e194d")
 	)
 	(label "CLK_ADF4351_LO"
-		(at 605.79 233.68 0)
+		(at 678.18 233.68 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -55648,7 +66144,7 @@
 		(uuid "ac8e351b-3b26-4f80-87f1-84fffed2f51b")
 	)
 	(label "LNA_IN"
-		(at 1088.39 339.09 0)
+		(at 1019.81 389.89 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -55658,7 +66154,7 @@
 		(uuid "ad77bf59-d7f4-4e27-a7ca-5ad04191b684")
 	)
 	(label "DEMOD_IN2-"
-		(at 723.9 337.82 180)
+		(at 654.05 392.43 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -55678,7 +66174,7 @@
 		(uuid "ae50c644-9a92-4f6d-a146-d8ea7e267cd2")
 	)
 	(label "LO_B_OUT+"
-		(at 762 337.82 0)
+		(at 659.13 337.82 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -55728,7 +66224,7 @@
 		(uuid "b2dce7b9-d17d-464c-ab68-28dae9b99d8c")
 	)
 	(label "QOUT-"
-		(at 641.35 337.82 0)
+		(at 571.5 392.43 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -55758,7 +66254,7 @@
 		(uuid "b4c1d2d5-77d3-40f6-a757-5f8461dd904e")
 	)
 	(label "D2B_ADC"
-		(at 472.44 410.21 90)
+		(at 430.53 435.61 90)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -55798,7 +66294,7 @@
 		(uuid "b8106c07-9256-4067-8f87-442f34b2367e")
 	)
 	(label "DEMOD_IN2-"
-		(at 647.7 424.18 180)
+		(at 767.08 412.75 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -55808,7 +66304,7 @@
 		(uuid "b850bbf1-804e-4fce-99d0-0df65784b5d6")
 	)
 	(label "DEMOD_RFIP"
-		(at 900.43 331.47 0)
+		(at 831.85 382.27 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -55828,7 +66324,7 @@
 		(uuid "baed321a-7b1b-4b7e-ae05-1ec6c287d320")
 	)
 	(label "D1A_ADC"
-		(at 488.95 355.6 180)
+		(at 447.04 381 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -55838,7 +66334,7 @@
 		(uuid "bc074def-c34d-4560-85b5-d15eca470019")
 	)
 	(label "LOIP_demod"
-		(at 859.79 337.82 180)
+		(at 756.92 337.82 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -55848,7 +66344,7 @@
 		(uuid "bcf66fe6-db6a-4cd4-8183-5a22391f5b22")
 	)
 	(label "LNA_IN"
-		(at 1082.04 339.09 180)
+		(at 1013.46 389.89 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -55878,7 +66374,7 @@
 		(uuid "bf3e6d5d-7308-493a-ab6b-42992dcbe79d")
 	)
 	(label "LO_B_OUT-"
-		(at 762 347.98 0)
+		(at 659.13 347.98 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -55898,7 +66394,7 @@
 		(uuid "c21d4b9c-e9b1-4aba-8088-d916e390830f")
 	)
 	(label "D1B_ADC"
-		(at 488.95 383.54 180)
+		(at 447.04 408.94 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -55918,7 +66414,7 @@
 		(uuid "c4e84dbc-3560-4680-8b3a-43ee37e6eb2d")
 	)
 	(label "I-ADC_IN"
-		(at 530.86 316.23 0)
+		(at 483.87 373.38 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -55938,7 +66434,7 @@
 		(uuid "c58ad5f1-4ebd-4f13-b0f8-7d56842287b3")
 	)
 	(label "CPOUT_ADF4351_LO"
-		(at 605.79 248.92 0)
+		(at 678.18 248.92 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -55948,7 +66444,7 @@
 		(uuid "c6edcfe2-b643-4b9c-9b39-74734c7e17ba")
 	)
 	(label "REFIN_ADF4351_OSCILLATOR"
-		(at 574.04 233.68 180)
+		(at 650.24 267.97 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -55958,7 +66454,7 @@
 		(uuid "c7960af3-43c8-4c3d-b8d7-f08a47ce9a99")
 	)
 	(label "ENCA"
-		(at 447.04 330.2 270)
+		(at 405.13 355.6 270)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -55978,7 +66474,7 @@
 		(uuid "c90806f6-8bd3-4798-b3b3-43a9c1e86666")
 	)
 	(label "D2A_ADC"
-		(at 472.44 326.39 270)
+		(at 430.53 351.79 270)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -56008,7 +66504,7 @@
 		(uuid "cdc8daaa-d5cc-4194-a4f7-ad1d3ca562d4")
 	)
 	(label "ENCB"
-		(at 447.04 406.4 90)
+		(at 405.13 431.8 90)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -56028,7 +66524,7 @@
 		(uuid "d27089e0-522d-4a74-939b-b7075797e905")
 	)
 	(label "D9B_ADC_MSB"
-		(at 454.66 416.56 90)
+		(at 412.75 441.96 90)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -56048,7 +66544,7 @@
 		(uuid "d63d2afd-0bdd-477d-8148-05b8fd187b09")
 	)
 	(label "LO_A_OUT+"
-		(at 638.81 284.48 90)
+		(at 711.2 284.48 90)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -56058,7 +66554,7 @@
 		(uuid "d65d401c-7df8-4a54-89e5-ae735485e103")
 	)
 	(label "D6B_ADC"
-		(at 462.28 410.21 90)
+		(at 420.37 435.61 90)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -56088,7 +66584,7 @@
 		(uuid "d7c8d697-3b09-4753-a10a-23071b2b114e")
 	)
 	(label "DEMOD_RFIP"
-		(at 635 397.51 180)
+		(at 754.38 386.08 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -56098,7 +66594,7 @@
 		(uuid "dbb040bd-a4d3-4abd-913c-3a72216f8387")
 	)
 	(label "DEMOD_RFIN"
-		(at 635 400.05 180)
+		(at 754.38 388.62 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -56138,7 +66634,7 @@
 		(uuid "df677447-acf5-41d8-8a3b-51d95715c398")
 	)
 	(label "LO_B_OUT+"
-		(at 643.89 284.48 90)
+		(at 716.28 284.48 90)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -56168,7 +66664,7 @@
 		(uuid "e4212a1e-34b2-4ef8-896a-1226f3de6203")
 	)
 	(label "DEMOD_RFIN"
-		(at 899.16 359.41 0)
+		(at 830.58 410.21 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -56178,7 +66674,7 @@
 		(uuid "e4430f3d-6bf5-49bd-ac89-13d5d5396178")
 	)
 	(label "DEMOD_IN2+"
-		(at 647.7 421.64 180)
+		(at 767.08 410.21 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -56198,7 +66694,7 @@
 		(uuid "e57e1802-8f77-4c40-833d-03fe9c433995")
 	)
 	(label "D7B_ADC"
-		(at 459.74 410.21 90)
+		(at 417.83 435.61 90)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -56218,7 +66714,7 @@
 		(uuid "e99fcb53-52d8-45e0-b875-00f54a4870e2")
 	)
 	(label "DEMOD_IN2+"
-		(at 723.9 332.74 180)
+		(at 654.05 387.35 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -56278,7 +66774,7 @@
 		(uuid "ec485abc-471e-49c8-8b33-f2e1fb5c30f7")
 	)
 	(label "D0B_ADC"
-		(at 488.95 381 180)
+		(at 447.04 406.4 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -56288,7 +66784,7 @@
 		(uuid "ed823724-2728-4915-9e10-628ec3f2ce28")
 	)
 	(label "LNA_OUT"
-		(at 1028.7 339.09 180)
+		(at 960.12 389.89 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -56318,7 +66814,7 @@
 		(uuid "ef2f46e7-d3fe-4b62-9f79-cdcc1ca77c69")
 	)
 	(label "SMA_RX_OUT"
-		(at 1144.27 339.09 180)
+		(at 1075.69 389.89 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -56328,7 +66824,7 @@
 		(uuid "f0ed98a0-f975-41cc-af14-5232367cf91b")
 	)
 	(label "DEMOD_IN1+"
-		(at 645.16 412.75 180)
+		(at 764.54 401.32 180)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -56338,7 +66834,7 @@
 		(uuid "f176e192-5727-4ffd-9348-a466af7b4123")
 	)
 	(label "D4B_ADC"
-		(at 467.36 410.21 90)
+		(at 425.45 435.61 90)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -56358,7 +66854,7 @@
 		(uuid "f89438fd-1d30-4994-b7ac-b84c46273165")
 	)
 	(label "Q-ADC_IN"
-		(at 426.72 378.46 0)
+		(at 384.81 403.86 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -56368,7 +66864,7 @@
 		(uuid "f93514c6-c95c-46f5-84d8-0367ece2280d")
 	)
 	(label "LOIN_demod"
-		(at 563.88 411.48 0)
+		(at 683.26 400.05 0)
 		(effects
 			(font
 				(size 1.27 1.27)
@@ -56499,7 +66995,7 @@
 	)
 	(global_label "LNA_ShutDown"
 		(shape input)
-		(at 1036.32 341.63 270)
+		(at 967.74 392.43 270)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -56509,7 +67005,7 @@
 		)
 		(uuid "3b94ffde-8981-4d64-84b2-ce3fb9f9d8b1")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 1036.32 358.1617 90)
+			(at 967.74 408.9617 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -56895,7 +67391,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 636.27 346.71 0)
+		(at 566.42 401.32 0)
 		(mirror x)
 		(unit 1)
 		(exclude_from_sim no)
@@ -56904,7 +67400,7 @@
 		(dnp no)
 		(uuid "0052df3e-19af-497c-9f6b-627828e04641")
 		(property "Reference" "C30"
-			(at 632.46 345.4399 0)
+			(at 562.61 400.0499 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -56913,7 +67409,7 @@
 			)
 		)
 		(property "Value" "100nF"
-			(at 632.46 347.9799 0)
+			(at 562.61 402.5899 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -56922,7 +67418,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 637.2352 342.9 0)
+			(at 567.3852 397.51 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -56931,7 +67427,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 636.27 346.71 0)
+			(at 566.42 401.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -56940,7 +67436,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 636.27 346.71 0)
+			(at 566.42 401.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -57040,7 +67536,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "01d618b9-bf4f-448e-b12a-6071755da368")
-		(property "Reference" "#PWR085"
+		(property "Reference" "#PWR85"
 			(at 311.15 648.97 0)
 			(effects
 				(font
@@ -57090,7 +67586,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR085")
+					(reference "#PWR85")
 					(unit 1)
 				)
 			)
@@ -57165,7 +67661,7 @@
 	)
 	(symbol
 		(lib_id "power:+3V3")
-		(at 490.22 358.14 0)
+		(at 448.31 383.54 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -57174,7 +67670,7 @@
 		(fields_autoplaced yes)
 		(uuid "025330ed-fde9-4ebd-ae4f-ac6f2c00f41e")
 		(property "Reference" "#PWR0283"
-			(at 490.22 361.95 0)
+			(at 448.31 387.35 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -57183,7 +67679,7 @@
 			)
 		)
 		(property "Value" "+3V"
-			(at 490.22 353.06 0)
+			(at 448.31 378.46 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -57191,7 +67687,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 490.22 358.14 0)
+			(at 448.31 383.54 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -57200,7 +67696,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 490.22 358.14 0)
+			(at 448.31 383.54 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -57209,7 +67705,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"+3V3\""
-			(at 490.22 358.14 0)
+			(at 448.31 383.54 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -57231,7 +67727,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 511.81 217.17 180)
+		(at 609.6 251.46 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -57240,7 +67736,7 @@
 		(fields_autoplaced yes)
 		(uuid "035ba7b5-3442-428e-ae7f-07b815b6ec92")
 		(property "Reference" "C82"
-			(at 508 218.4401 0)
+			(at 605.79 252.7301 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -57249,7 +67745,7 @@
 			)
 		)
 		(property "Value" "0.1uF"
-			(at 508 215.9001 0)
+			(at 605.79 250.1901 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -57258,7 +67754,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 510.8448 213.36 0)
+			(at 608.6348 247.65 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -57267,7 +67763,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 511.81 217.17 0)
+			(at 609.6 251.46 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -57276,7 +67772,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 511.81 217.17 0)
+			(at 609.6 251.46 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -57301,7 +67797,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 1057.91 359.41 0)
+		(at 989.33 410.21 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -57309,8 +67805,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "03c9b703-1a51-4fc1-b3f5-6a895d2dcf2f")
-		(property "Reference" "#PWR029"
-			(at 1057.91 365.76 0)
+		(property "Reference" "#PWR29"
+			(at 989.33 416.56 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -57319,7 +67815,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 1057.91 364.49 0)
+			(at 989.33 415.29 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -57327,7 +67823,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 1057.91 359.41 0)
+			(at 989.33 410.21 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -57336,7 +67832,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 1057.91 359.41 0)
+			(at 989.33 410.21 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -57345,7 +67841,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 1057.91 359.41 0)
+			(at 989.33 410.21 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -57359,7 +67855,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR029")
+					(reference "#PWR29")
 					(unit 1)
 				)
 			)
@@ -57572,7 +68068,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 1096.01 317.5 90)
+		(at 1027.43 368.3 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -57580,8 +68076,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "04188c40-138a-4836-86e1-bdb25ecde27e")
-		(property "Reference" "#PWR0322"
-			(at 1102.36 317.5 0)
+		(property "Reference" "#PWR322"
+			(at 1033.78 368.3 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -57590,7 +68086,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 1099.82 317.4999 90)
+			(at 1031.24 368.2999 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -57599,7 +68095,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 1096.01 317.5 0)
+			(at 1027.43 368.3 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -57608,7 +68104,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 1096.01 317.5 0)
+			(at 1027.43 368.3 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -57617,7 +68113,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 1096.01 317.5 0)
+			(at 1027.43 368.3 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -57631,7 +68127,7 @@
 		(instances
 			(project ""
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0322")
+					(reference "#PWR322")
 					(unit 1)
 				)
 			)
@@ -57647,7 +68143,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "04484831-0fb8-4308-8a71-aa47870dd8e1")
-		(property "Reference" "#PWR0308"
+		(property "Reference" "#PWR308"
 			(at 137.16 53.34 0)
 			(effects
 				(font
@@ -57698,7 +68194,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0308")
+					(reference "#PWR308")
 					(unit 1)
 				)
 			)
@@ -57911,7 +68407,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 631.19 424.18 90)
+		(at 750.57 412.75 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -57919,7 +68415,7 @@
 		(dnp no)
 		(uuid "05fcbc33-93e3-43a5-bb11-28539dd651d9")
 		(property "Reference" "R23"
-			(at 632.714 425.958 90)
+			(at 752.094 414.528 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -57927,7 +68423,7 @@
 			)
 		)
 		(property "Value" "1k"
-			(at 628.904 425.958 90)
+			(at 748.284 414.528 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -57935,7 +68431,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 631.444 423.164 90)
+			(at 750.824 411.734 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -57944,7 +68440,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 631.19 424.18 0)
+			(at 750.57 412.75 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -57953,7 +68449,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 631.19 424.18 0)
+			(at 750.57 412.75 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -57978,7 +68474,7 @@
 	)
 	(symbol
 		(lib_id "Device:L")
-		(at 570.23 354.33 270)
+		(at 523.24 411.48 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -57987,7 +68483,7 @@
 		(fields_autoplaced yes)
 		(uuid "0638725a-0f8a-4a5b-b419-49f3befc60cf")
 		(property "Reference" "L13"
-			(at 570.23 359.41 90)
+			(at 523.24 416.56 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -57995,7 +68491,7 @@
 			)
 		)
 		(property "Value" "27uH"
-			(at 570.23 356.87 90)
+			(at 523.24 414.02 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -58003,7 +68499,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 570.23 354.33 0)
+			(at 523.24 411.48 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -58012,7 +68508,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 570.23 354.33 0)
+			(at 523.24 411.48 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -58021,7 +68517,7 @@
 			)
 		)
 		(property "Description" "Inductor"
-			(at 570.23 354.33 0)
+			(at 523.24 411.48 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -58121,7 +68617,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "075949bc-3dc5-46d3-aab1-1c8e54b17e1b")
-		(property "Reference" "#PWR0274"
+		(property "Reference" "#PWR274"
 			(at 654.05 167.64 0)
 			(effects
 				(font
@@ -58172,7 +68668,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0274")
+					(reference "#PWR274")
 					(unit 1)
 				)
 			)
@@ -58250,7 +68746,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 551.18 408.94 0)
+		(at 670.56 397.51 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -58258,8 +68754,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "0885b063-5c61-4106-a823-162bdbd1cab0")
-		(property "Reference" "#PWR0124"
-			(at 551.18 415.29 0)
+		(property "Reference" "#PWR124"
+			(at 670.56 403.86 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -58268,7 +68764,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 551.18 414.02 0)
+			(at 670.56 402.59 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -58277,7 +68773,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 551.18 408.94 0)
+			(at 670.56 397.51 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -58286,7 +68782,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 551.18 408.94 0)
+			(at 670.56 397.51 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -58295,7 +68791,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 551.18 408.94 0)
+			(at 670.56 397.51 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -58309,7 +68805,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0124")
+					(reference "#PWR124")
 					(unit 1)
 				)
 			)
@@ -58395,7 +68891,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "08d6bb96-266e-468f-8669-00eafb899437")
-		(property "Reference" "#PWR0167"
+		(property "Reference" "#PWR167"
 			(at 24.13 129.54 0)
 			(effects
 				(font
@@ -58446,7 +68942,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0167")
+					(reference "#PWR167")
 					(unit 1)
 				)
 			)
@@ -58454,7 +68950,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 449.58 420.37 0)
+		(at 407.67 445.77 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -58462,8 +68958,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "08fd76fd-0ec1-4799-af99-a3fcd3713157")
-		(property "Reference" "#PWR0288"
-			(at 449.58 426.72 0)
+		(property "Reference" "#PWR288"
+			(at 407.67 452.12 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -58472,7 +68968,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 449.58 425.45 0)
+			(at 407.67 450.85 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -58481,7 +68977,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 449.58 420.37 0)
+			(at 407.67 445.77 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -58490,7 +68986,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 449.58 420.37 0)
+			(at 407.67 445.77 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -58499,7 +68995,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 449.58 420.37 0)
+			(at 407.67 445.77 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -58513,7 +69009,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0288")
+					(reference "#PWR288")
 					(unit 1)
 				)
 			)
@@ -58529,7 +69025,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "0918729c-2ee8-4cd4-bd5d-898ea8476207")
-		(property "Reference" "#PWR0147"
+		(property "Reference" "#PWR147"
 			(at 848.36 116.84 0)
 			(effects
 				(font
@@ -58580,7 +69076,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0147")
+					(reference "#PWR147")
 					(unit 1)
 				)
 			)
@@ -58596,7 +69092,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "096a6522-30b3-43d5-b42d-69306ebaa8c6")
-		(property "Reference" "#PWR0343"
+		(property "Reference" "#PWR343"
 			(at 297.18 278.13 0)
 			(effects
 				(font
@@ -58647,7 +69143,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0343")
+					(reference "#PWR343")
 					(unit 1)
 				)
 			)
@@ -58721,7 +69217,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 1132.84 344.17 90)
+		(at 1064.26 394.97 90)
 		(mirror x)
 		(unit 1)
 		(exclude_from_sim no)
@@ -58730,8 +69226,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "0a8e7acd-fd9d-48e6-b94d-d3e406beac3b")
-		(property "Reference" "#PWR027"
-			(at 1139.19 344.17 0)
+		(property "Reference" "#PWR27"
+			(at 1070.61 394.97 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -58740,7 +69236,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 1136.65 344.1699 90)
+			(at 1068.07 394.9699 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -58749,7 +69245,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 1132.84 344.17 0)
+			(at 1064.26 394.97 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -58758,7 +69254,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 1132.84 344.17 0)
+			(at 1064.26 394.97 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -58767,7 +69263,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 1132.84 344.17 0)
+			(at 1064.26 394.97 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -58781,7 +69277,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR027")
+					(reference "#PWR27")
 					(unit 1)
 				)
 			)
@@ -58930,7 +69426,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "0b28af23-d033-4280-97f9-b3e64007e296")
-		(property "Reference" "#PWR023"
+		(property "Reference" "#PWR23"
 			(at 669.29 90.17 0)
 			(effects
 				(font
@@ -58981,7 +69477,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR023")
+					(reference "#PWR23")
 					(unit 1)
 				)
 			)
@@ -59129,7 +69625,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 575.31 392.43 270)
+		(at 694.69 381 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -59137,8 +69633,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "0c800828-f98a-41f4-b704-40da80a3705d")
-		(property "Reference" "#PWR0129"
-			(at 568.96 392.43 0)
+		(property "Reference" "#PWR129"
+			(at 688.34 381 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -59147,7 +69643,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 571.5 392.4299 90)
+			(at 690.88 380.9999 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -59157,7 +69653,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 575.31 392.43 0)
+			(at 694.69 381 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -59166,7 +69662,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 575.31 392.43 0)
+			(at 694.69 381 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -59175,7 +69671,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 575.31 392.43 0)
+			(at 694.69 381 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -59189,7 +69685,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0129")
+					(reference "#PWR129")
 					(unit 1)
 				)
 			)
@@ -59205,7 +69701,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "0cb903c4-674c-405b-a38d-7ab3c3b25d33")
-		(property "Reference" "#PWR0152"
+		(property "Reference" "#PWR152"
 			(at 610.87 106.68 0)
 			(effects
 				(font
@@ -59256,7 +69752,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0152")
+					(reference "#PWR152")
 					(unit 1)
 				)
 			)
@@ -59264,7 +69760,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 562.61 389.89 0)
+		(at 681.99 378.46 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -59272,7 +69768,7 @@
 		(dnp no)
 		(uuid "0f289276-484f-4b9f-aac7-b17b14d9511f")
 		(property "Reference" "C49"
-			(at 565.912 388.62 0)
+			(at 685.292 377.19 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -59281,7 +69777,7 @@
 			)
 		)
 		(property "Value" "100pF"
-			(at 565.15 390.398 0)
+			(at 684.53 378.968 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -59290,7 +69786,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 563.5752 393.7 0)
+			(at 682.9552 382.27 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -59299,7 +69795,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 562.61 389.89 0)
+			(at 681.99 378.46 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -59308,7 +69804,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 562.61 389.89 0)
+			(at 681.99 378.46 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -59341,7 +69837,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "0f2ca6e4-dc7e-4cbf-ac62-0cf22fc4e63e")
-		(property "Reference" "#PWR0155"
+		(property "Reference" "#PWR155"
 			(at 497.84 127 0)
 			(effects
 				(font
@@ -59392,7 +69888,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0155")
+					(reference "#PWR155")
 					(unit 1)
 				)
 			)
@@ -59409,7 +69905,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "0f8205dd-158d-4cd9-8742-70a75564dcbe")
-		(property "Reference" "#PWR0177"
+		(property "Reference" "#PWR177"
 			(at 138.43 290.83 0)
 			(effects
 				(font
@@ -59459,7 +69955,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0177")
+					(reference "#PWR177")
 					(unit 1)
 				)
 			)
@@ -59475,7 +69971,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "0f91747a-5647-4c99-90ab-d3f0ed6725f7")
-		(property "Reference" "#PWR0342"
+		(property "Reference" "#PWR342"
 			(at 222.25 267.97 0)
 			(effects
 				(font
@@ -59526,7 +70022,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0342")
+					(reference "#PWR342")
 					(unit 1)
 				)
 			)
@@ -59669,7 +70165,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 563.88 322.58 180)
+		(at 516.89 379.73 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -59677,7 +70173,7 @@
 		(dnp no)
 		(uuid "114787d1-aecc-491a-868f-786bcb32721f")
 		(property "Reference" "C41"
-			(at 560.832 323.596 0)
+			(at 513.842 380.746 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -59686,7 +70182,7 @@
 			)
 		)
 		(property "Value" "91pF"
-			(at 561.34 321.564 0)
+			(at 514.35 378.714 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -59695,7 +70191,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 562.9148 318.77 0)
+			(at 515.9248 375.92 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -59704,7 +70200,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 563.88 322.58 0)
+			(at 516.89 379.73 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -59713,7 +70209,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 563.88 322.58 0)
+			(at 516.89 379.73 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -59746,7 +70242,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "11ebb745-0113-4662-8ce4-390940665ced")
-		(property "Reference" "#PWR018"
+		(property "Reference" "#PWR18"
 			(at 744.22 139.7 0)
 			(effects
 				(font
@@ -59797,7 +70293,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR018")
+					(reference "#PWR18")
 					(unit 1)
 				)
 			)
@@ -59805,7 +70301,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 514.35 374.65 0)
+		(at 472.44 400.05 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -59813,7 +70309,7 @@
 		(dnp no)
 		(uuid "1230fd9a-6532-4aa7-9a10-745a89dcff70")
 		(property "Reference" "C131"
-			(at 517.144 373.38 0)
+			(at 475.234 398.78 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -59822,7 +70318,7 @@
 			)
 		)
 		(property "Value" "0.1uF"
-			(at 517.144 375.92 0)
+			(at 475.234 401.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -59831,7 +70327,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 515.3152 378.46 0)
+			(at 473.4052 403.86 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -59840,7 +70336,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 514.35 374.65 0)
+			(at 472.44 400.05 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -59849,7 +70345,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 514.35 374.65 0)
+			(at 472.44 400.05 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -60011,7 +70507,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 509.27 374.65 0)
+		(at 467.36 400.05 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -60019,7 +70515,7 @@
 		(dnp no)
 		(uuid "138c1558-ccdd-4d55-a40f-5c66f82dd3f9")
 		(property "Reference" "C130"
-			(at 501.142 373.38 0)
+			(at 459.232 398.78 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -60028,7 +70524,7 @@
 			)
 		)
 		(property "Value" "0.1uF"
-			(at 501.142 375.92 0)
+			(at 459.232 401.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -60037,7 +70533,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 510.2352 378.46 0)
+			(at 468.3252 403.86 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -60046,7 +70542,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 509.27 374.65 0)
+			(at 467.36 400.05 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -60055,7 +70551,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 509.27 374.65 0)
+			(at 467.36 400.05 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -60080,7 +70576,7 @@
 	)
 	(symbol
 		(lib_id "power:+3.3V")
-		(at 657.86 274.32 270)
+		(at 730.25 274.32 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -60089,7 +70585,7 @@
 		(fields_autoplaced yes)
 		(uuid "13904895-7096-475c-beb7-b64a75e3c55f")
 		(property "Reference" "#PWR0114"
-			(at 654.05 274.32 0)
+			(at 726.44 274.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -60098,7 +70594,7 @@
 			)
 		)
 		(property "Value" "+3.3V"
-			(at 661.67 274.3199 90)
+			(at 734.06 274.3199 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -60107,7 +70603,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 657.86 274.32 0)
+			(at 730.25 274.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -60116,7 +70612,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 657.86 274.32 0)
+			(at 730.25 274.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -60125,7 +70621,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"+3.3V\""
-			(at 657.86 274.32 0)
+			(at 730.25 274.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -60147,7 +70643,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 690.88 234.95 0)
+		(at 763.27 234.95 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -60155,7 +70651,7 @@
 		(dnp no)
 		(uuid "13bf345a-f769-4736-87c5-afef613fe110")
 		(property "Reference" "C156"
-			(at 694.69 233.6799 0)
+			(at 767.08 233.6799 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -60164,7 +70660,7 @@
 			)
 		)
 		(property "Value" "0.1uF"
-			(at 694.69 236.2199 0)
+			(at 767.08 236.2199 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -60173,7 +70669,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 691.8452 238.76 0)
+			(at 764.2352 238.76 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -60182,7 +70678,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 690.88 234.95 0)
+			(at 763.27 234.95 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -60191,7 +70687,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 690.88 234.95 0)
+			(at 763.27 234.95 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -60284,7 +70780,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 454.66 233.68 0)
+		(at 552.45 267.97 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -60292,8 +70788,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "156eb34e-97e1-4c11-8718-211db8513416")
-		(property "Reference" "#PWR0241"
-			(at 454.66 240.03 0)
+		(property "Reference" "#PWR241"
+			(at 552.45 274.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -60302,7 +70798,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 454.66 238.76 0)
+			(at 552.45 273.05 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -60310,7 +70806,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 454.66 233.68 0)
+			(at 552.45 267.97 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -60319,7 +70815,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 454.66 233.68 0)
+			(at 552.45 267.97 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -60328,7 +70824,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 454.66 233.68 0)
+			(at 552.45 267.97 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -60342,7 +70838,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0241")
+					(reference "#PWR241")
 					(unit 1)
 				)
 			)
@@ -60495,7 +70991,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "16b711c5-fbcd-4ff3-a77b-9f819e3da5d8")
-		(property "Reference" "#PWR0148"
+		(property "Reference" "#PWR148"
 			(at 848.36 107.95 0)
 			(effects
 				(font
@@ -60546,7 +71042,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0148")
+					(reference "#PWR148")
 					(unit 1)
 				)
 			)
@@ -60562,7 +71058,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "17aa12ae-b6f3-4ab0-a86b-4d736c81ee7c")
-		(property "Reference" "#PWR0247"
+		(property "Reference" "#PWR247"
 			(at 137.16 63.5 0)
 			(effects
 				(font
@@ -60613,7 +71109,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0247")
+					(reference "#PWR247")
 					(unit 1)
 				)
 			)
@@ -60688,7 +71184,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 796.29 355.6 0)
+		(at 693.42 355.6 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -60696,8 +71192,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "17ead3b3-dc2b-4707-b353-02aa7d394643")
-		(property "Reference" "#PWR0315"
-			(at 796.29 361.95 0)
+		(property "Reference" "#PWR315"
+			(at 693.42 361.95 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -60706,7 +71202,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 796.29 360.68 0)
+			(at 693.42 360.68 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -60715,7 +71211,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 796.29 355.6 0)
+			(at 693.42 355.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -60724,7 +71220,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 796.29 355.6 0)
+			(at 693.42 355.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -60733,7 +71229,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 796.29 355.6 0)
+			(at 693.42 355.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -60747,7 +71243,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0315")
+					(reference "#PWR315")
 					(unit 1)
 				)
 			)
@@ -60822,7 +71318,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 671.83 217.17 0)
+		(at 744.22 217.17 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -60830,7 +71326,7 @@
 		(dnp no)
 		(uuid "183fdae3-cada-41e0-afd0-4e6d653823ac")
 		(property "Reference" "C88"
-			(at 664.972 215.138 0)
+			(at 737.362 215.138 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -60839,7 +71335,7 @@
 			)
 		)
 		(property "Value" "10pF"
-			(at 664.972 217.678 0)
+			(at 737.362 217.678 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -60848,7 +71344,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 672.7952 220.98 0)
+			(at 745.1852 220.98 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -60857,7 +71353,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 671.83 217.17 0)
+			(at 744.22 217.17 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -60866,7 +71362,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 671.83 217.17 0)
+			(at 744.22 217.17 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -60966,7 +71462,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "196583fe-8faf-4d33-a033-c9c1526073c3")
-		(property "Reference" "#PWR0180"
+		(property "Reference" "#PWR180"
 			(at 297.18 267.97 0)
 			(effects
 				(font
@@ -61017,7 +71513,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0180")
+					(reference "#PWR180")
 					(unit 1)
 				)
 			)
@@ -61033,7 +71529,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "1967f082-28b7-462d-8af1-71d19ac6bea3")
-		(property "Reference" "#PWR092"
+		(property "Reference" "#PWR92"
 			(at 222.25 191.77 0)
 			(effects
 				(font
@@ -61084,7 +71580,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR092")
+					(reference "#PWR92")
 					(unit 1)
 				)
 			)
@@ -61100,7 +71596,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "1a225d3c-163c-48b2-b26f-4b7e156b8f4d")
-		(property "Reference" "#PWR0270"
+		(property "Reference" "#PWR270"
 			(at 609.6 138.43 0)
 			(effects
 				(font
@@ -61151,7 +71647,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0270")
+					(reference "#PWR270")
 					(unit 1)
 				)
 			)
@@ -61370,7 +71866,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "1ce6db7e-391c-438a-975d-b6406c0944e9")
-		(property "Reference" "#PWR0224"
+		(property "Reference" "#PWR224"
 			(at 139.7 576.58 0)
 			(effects
 				(font
@@ -61420,7 +71916,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0224")
+					(reference "#PWR224")
 					(unit 1)
 				)
 			)
@@ -61428,7 +71924,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 557.53 191.77 90)
+		(at 615.95 209.55 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -61437,7 +71933,7 @@
 		(fields_autoplaced yes)
 		(uuid "1e3378e5-e190-4b94-a5ad-5619bbd95653")
 		(property "Reference" "R36"
-			(at 557.53 185.42 90)
+			(at 615.95 203.2 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -61445,7 +71941,7 @@
 			)
 		)
 		(property "Value" "680"
-			(at 557.53 187.96 90)
+			(at 615.95 205.74 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -61453,7 +71949,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 557.784 190.754 90)
+			(at 616.204 208.534 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -61462,7 +71958,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 557.53 191.77 0)
+			(at 615.95 209.55 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -61471,7 +71967,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 557.53 191.77 0)
+			(at 615.95 209.55 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -61504,7 +72000,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "1ec77269-2acf-4cba-956d-8ad7a0df4f08")
-		(property "Reference" "#PWR0217"
+		(property "Reference" "#PWR217"
 			(at 154.94 615.95 0)
 			(effects
 				(font
@@ -61554,7 +72050,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0217")
+					(reference "#PWR217")
 					(unit 1)
 				)
 			)
@@ -61562,7 +72058,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 789.94 341.63 0)
+		(at 687.07 341.63 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -61571,7 +72067,7 @@
 		(fields_autoplaced yes)
 		(uuid "1ed9348f-a070-4867-b3a0-6fe622dccb4f")
 		(property "Reference" "R37"
-			(at 792.48 340.3599 0)
+			(at 689.61 340.3599 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -61580,7 +72076,7 @@
 			)
 		)
 		(property "Value" "100"
-			(at 792.48 342.8999 0)
+			(at 689.61 342.8999 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -61589,7 +72085,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 790.956 341.884 90)
+			(at 688.086 341.884 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -61598,7 +72094,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 789.94 341.63 0)
+			(at 687.07 341.63 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -61607,7 +72103,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 789.94 341.63 0)
+			(at 687.07 341.63 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -61787,7 +72283,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "1f1e91d0-e37a-4785-97d3-6ec825134169")
-		(property "Reference" "#PWR041"
+		(property "Reference" "#PWR41"
 			(at 297.18 240.03 0)
 			(effects
 				(font
@@ -61838,7 +72334,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR041")
+					(reference "#PWR41")
 					(unit 1)
 				)
 			)
@@ -61916,7 +72412,7 @@
 	)
 	(symbol
 		(lib_id "Device:L")
-		(at 557.53 328.93 270)
+		(at 510.54 386.08 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -61924,7 +72420,7 @@
 		(dnp no)
 		(uuid "2092299a-33b6-48b5-828e-2ef209943b6c")
 		(property "Reference" "L12"
-			(at 557.53 327.406 90)
+			(at 510.54 384.556 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -61932,7 +72428,7 @@
 			)
 		)
 		(property "Value" "10uH"
-			(at 557.53 331.47 90)
+			(at 510.54 388.62 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -61940,7 +72436,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 557.53 328.93 0)
+			(at 510.54 386.08 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -61949,7 +72445,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 557.53 328.93 0)
+			(at 510.54 386.08 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -61958,7 +72454,7 @@
 			)
 		)
 		(property "Description" "Inductor"
-			(at 557.53 328.93 0)
+			(at 510.54 386.08 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -61991,7 +72487,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "20a29d40-e019-4e31-ab02-fa7f7dfbb59d")
-		(property "Reference" "#PWR0344"
+		(property "Reference" "#PWR344"
 			(at 297.18 237.49 0)
 			(effects
 				(font
@@ -62042,7 +72538,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0344")
+					(reference "#PWR344")
 					(unit 1)
 				)
 			)
@@ -62135,7 +72631,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "213a7c24-2e15-42f7-8d7f-1811a32c7aeb")
-		(property "Reference" "#PWR0276"
+		(property "Reference" "#PWR276"
 			(at 615.95 167.64 0)
 			(effects
 				(font
@@ -62186,7 +72682,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0276")
+					(reference "#PWR276")
 					(unit 1)
 				)
 			)
@@ -62261,7 +72757,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 480.06 378.46 90)
+		(at 438.15 403.86 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -62269,8 +72765,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "22bc32bb-9a24-4119-8f40-07c5d21ee26e")
-		(property "Reference" "#PWR052"
-			(at 486.41 378.46 0)
+		(property "Reference" "#PWR52"
+			(at 444.5 403.86 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -62279,7 +72775,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 483.87 378.4599 90)
+			(at 441.96 403.8599 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -62289,7 +72785,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 480.06 378.46 0)
+			(at 438.15 403.86 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -62298,7 +72794,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 480.06 378.46 0)
+			(at 438.15 403.86 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -62307,7 +72803,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 480.06 378.46 0)
+			(at 438.15 403.86 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -62321,7 +72817,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR052")
+					(reference "#PWR52")
 					(unit 1)
 				)
 			)
@@ -62407,7 +72903,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "239cb2b0-4902-4353-8c3f-ed28562728a9")
-		(property "Reference" "#PWR039"
+		(property "Reference" "#PWR39"
 			(at 222.25 370.84 0)
 			(effects
 				(font
@@ -62458,7 +72954,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR039")
+					(reference "#PWR39")
 					(unit 1)
 				)
 			)
@@ -62466,7 +72962,7 @@
 	)
 	(symbol
 		(lib_id "LIB_IRISHSAT:ADF4351BCPZ-RL7")
-		(at 623.57 233.68 0)
+		(at 695.96 233.68 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -62474,7 +72970,7 @@
 		(dnp no)
 		(uuid "2489abe8-62a5-4711-bea7-8d8467959e9f")
 		(property "Reference" "IC4"
-			(at 643.89 216.408 0)
+			(at 716.28 216.408 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -62482,7 +72978,7 @@
 			)
 		)
 		(property "Value" "ADF4351BCPZ-RL7"
-			(at 643.89 218.948 0)
+			(at 716.28 218.948 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -62490,7 +72986,7 @@
 			)
 		)
 		(property "Footprint" "LIB_IRISHSAT:QFN50P500X500X80-33N-D"
-			(at 655.32 303.2 0)
+			(at 727.71 303.2 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -62500,7 +72996,7 @@
 			)
 		)
 		(property "Datasheet" "http://www.analog.com/media/en/technical-documentation/data-sheets/ADF4351.pdf"
-			(at 655.32 403.2 0)
+			(at 727.71 403.2 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -62510,7 +73006,7 @@
 			)
 		)
 		(property "Description" "Phase Locked Loops - PLL 34-4400MHz PLL with Integrated VCO"
-			(at 623.57 233.68 0)
+			(at 695.96 233.68 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -62519,7 +73015,7 @@
 			)
 		)
 		(property "Height" "0.8"
-			(at 655.32 603.2 0)
+			(at 727.71 603.2 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -62529,7 +73025,7 @@
 			)
 		)
 		(property "Mouser Part Number" "584-ADF4351BCPZ-R7"
-			(at 655.32 703.2 0)
+			(at 727.71 703.2 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -62539,7 +73035,7 @@
 			)
 		)
 		(property "Mouser Price/Stock" "https://www.mouser.co.uk/ProductDetail/Analog-Devices/ADF4351BCPZ-RL7?qs=BpaRKvA4VqGpsaYrVKmugA%3D%3D"
-			(at 655.32 803.2 0)
+			(at 727.71 803.2 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -62549,7 +73045,7 @@
 			)
 		)
 		(property "Manufacturer_Name" "Analog Devices"
-			(at 655.32 903.2 0)
+			(at 727.71 903.2 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -62559,7 +73055,7 @@
 			)
 		)
 		(property "Manufacturer_Part_Number" "ADF4351BCPZ-RL7"
-			(at 655.32 1003.2 0)
+			(at 727.71 1003.2 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -62678,7 +73174,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 652.78 278.13 180)
+		(at 725.17 278.13 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -62687,7 +73183,7 @@
 		(fields_autoplaced yes)
 		(uuid "24d68a0b-11e8-44db-a68a-5a2ac1f6a80e")
 		(property "Reference" "C44"
-			(at 656.59 276.8599 0)
+			(at 728.98 276.8599 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -62696,7 +73192,7 @@
 			)
 		)
 		(property "Value" "1uF"
-			(at 656.59 279.3999 0)
+			(at 728.98 279.3999 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -62705,7 +73201,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 651.8148 274.32 0)
+			(at 724.2048 274.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -62714,7 +73210,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 652.78 278.13 0)
+			(at 725.17 278.13 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -62723,7 +73219,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 652.78 278.13 0)
+			(at 725.17 278.13 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -62748,7 +73244,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 581.66 405.13 270)
+		(at 701.04 393.7 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -62756,8 +73252,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "255bf9ae-6ef0-4fa6-a22c-b9db2ac99113")
-		(property "Reference" "#PWR0127"
-			(at 575.31 405.13 0)
+		(property "Reference" "#PWR127"
+			(at 694.69 393.7 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -62766,7 +73262,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 577.85 405.1299 90)
+			(at 697.23 393.6999 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -62776,7 +73272,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 581.66 405.13 0)
+			(at 701.04 393.7 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -62785,7 +73281,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 581.66 405.13 0)
+			(at 701.04 393.7 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -62794,7 +73290,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 581.66 405.13 0)
+			(at 701.04 393.7 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -62808,7 +73304,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0127")
+					(reference "#PWR127")
 					(unit 1)
 				)
 			)
@@ -62886,7 +73382,7 @@
 	)
 	(symbol
 		(lib_id "power:+3.3V")
-		(at 659.13 251.46 270)
+		(at 731.52 251.46 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -62895,7 +73391,7 @@
 		(fields_autoplaced yes)
 		(uuid "2603ddeb-9c92-4cb9-925e-86212b8ec4e5")
 		(property "Reference" "#PWR0236"
-			(at 655.32 251.46 0)
+			(at 727.71 251.46 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -62904,7 +73400,7 @@
 			)
 		)
 		(property "Value" "+3.3V"
-			(at 662.94 251.4599 90)
+			(at 735.33 251.4599 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -62913,7 +73409,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 659.13 251.46 0)
+			(at 731.52 251.46 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -62922,7 +73418,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 659.13 251.46 0)
+			(at 731.52 251.46 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -62931,7 +73427,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"+3.3V\""
-			(at 659.13 251.46 0)
+			(at 731.52 251.46 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -62953,7 +73449,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 514.35 237.49 0)
+		(at 612.14 271.78 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -62962,7 +73458,7 @@
 		(fields_autoplaced yes)
 		(uuid "27b5a890-19c3-4a73-a063-8096626e40fb")
 		(property "Reference" "R52"
-			(at 516.89 236.2199 0)
+			(at 614.68 270.5099 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -62971,7 +73467,7 @@
 			)
 		)
 		(property "Value" "51"
-			(at 516.89 238.7599 0)
+			(at 614.68 273.0499 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -62980,7 +73476,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 515.366 237.744 90)
+			(at 613.156 272.034 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -62989,7 +73485,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 514.35 237.49 0)
+			(at 612.14 271.78 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -62998,7 +73494,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 514.35 237.49 0)
+			(at 612.14 271.78 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -63100,7 +73596,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "28391235-71ba-42e8-8c32-6f7d1313f9b2")
-		(property "Reference" "#PWR098"
+		(property "Reference" "#PWR98"
 			(at 222.25 85.09 0)
 			(effects
 				(font
@@ -63151,7 +73647,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR098")
+					(reference "#PWR98")
 					(unit 1)
 				)
 			)
@@ -63167,7 +73663,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "2839efe5-9bcf-41bf-a022-41306153a7f0")
-		(property "Reference" "#PWR089"
+		(property "Reference" "#PWR89"
 			(at 114.3 694.69 0)
 			(effects
 				(font
@@ -63217,7 +73713,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR089")
+					(reference "#PWR89")
 					(unit 1)
 				)
 			)
@@ -63225,7 +73721,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 551.18 203.2 0)
+		(at 609.6 220.98 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -63234,7 +73730,7 @@
 		(fields_autoplaced yes)
 		(uuid "2879bb0a-793d-4e1a-bcb9-445db466f6c0")
 		(property "Reference" "R35"
-			(at 553.72 201.9299 0)
+			(at 612.14 219.7099 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -63243,7 +73739,7 @@
 			)
 		)
 		(property "Value" "360"
-			(at 553.72 204.4699 0)
+			(at 612.14 222.2499 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -63252,7 +73748,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 552.196 203.454 90)
+			(at 610.616 221.234 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -63261,7 +73757,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 551.18 203.2 0)
+			(at 609.6 220.98 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -63270,7 +73766,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 551.18 203.2 0)
+			(at 609.6 220.98 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -63295,7 +73791,7 @@
 	)
 	(symbol
 		(lib_id "power:+1V1")
-		(at 635 342.9 90)
+		(at 565.15 397.51 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -63303,7 +73799,7 @@
 		(dnp no)
 		(uuid "28c95cdd-5e19-4688-a32e-9fc123a4aedb")
 		(property "Reference" "#PWR0111"
-			(at 638.81 342.9 0)
+			(at 568.96 397.51 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -63312,7 +73808,7 @@
 			)
 		)
 		(property "Value" "+1V"
-			(at 631.698 342.9 90)
+			(at 561.848 397.51 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -63321,7 +73817,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 635 342.9 0)
+			(at 565.15 397.51 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -63330,7 +73826,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 635 342.9 0)
+			(at 565.15 397.51 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -63339,7 +73835,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"+1V1\""
-			(at 635 342.9 0)
+			(at 565.15 397.51 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -63436,7 +73932,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "29b1830d-2410-419a-8799-e17766cac422")
-		(property "Reference" "#PWR011"
+		(property "Reference" "#PWR11"
 			(at 669.29 74.93 0)
 			(effects
 				(font
@@ -63487,7 +73983,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR011")
+					(reference "#PWR11")
 					(unit 1)
 				)
 			)
@@ -63495,7 +73991,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 659.13 255.27 180)
+		(at 731.52 255.27 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -63504,7 +74000,7 @@
 		(fields_autoplaced yes)
 		(uuid "29db8ca2-1870-4b01-9423-0d3285432806")
 		(property "Reference" "C45"
-			(at 662.94 253.9999 0)
+			(at 735.33 253.9999 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -63513,7 +74009,7 @@
 			)
 		)
 		(property "Value" "1uF"
-			(at 662.94 256.5399 0)
+			(at 735.33 256.5399 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -63522,7 +74018,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 658.1648 251.46 0)
+			(at 730.5548 251.46 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -63531,7 +74027,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 659.13 255.27 0)
+			(at 731.52 255.27 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -63540,7 +74036,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 659.13 255.27 0)
+			(at 731.52 255.27 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -63573,7 +74069,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "29e61967-b698-4051-aed2-f0bcbe718d50")
-		(property "Reference" "#PWR037"
+		(property "Reference" "#PWR37"
 			(at 222.25 403.86 0)
 			(effects
 				(font
@@ -63624,7 +74120,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR037")
+					(reference "#PWR37")
 					(unit 1)
 				)
 			)
@@ -63632,7 +74128,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 551.18 322.58 180)
+		(at 504.19 379.73 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -63640,7 +74136,7 @@
 		(dnp no)
 		(uuid "29eb50e3-6a36-4e3b-b178-63eecde70f07")
 		(property "Reference" "C43"
-			(at 548.386 323.596 0)
+			(at 501.396 380.746 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -63649,7 +74145,7 @@
 			)
 		)
 		(property "Value" "68pF"
-			(at 548.64 321.564 0)
+			(at 501.65 378.714 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -63658,7 +74154,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 550.2148 318.77 0)
+			(at 503.2248 375.92 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -63667,7 +74163,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 551.18 322.58 0)
+			(at 504.19 379.73 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -63676,7 +74172,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 551.18 322.58 0)
+			(at 504.19 379.73 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -63838,7 +74334,7 @@
 	)
 	(symbol
 		(lib_id "Device:L")
-		(at 911.86 335.28 0)
+		(at 843.28 386.08 0)
 		(mirror x)
 		(unit 1)
 		(exclude_from_sim no)
@@ -63847,7 +74343,7 @@
 		(dnp no)
 		(uuid "2abf9151-a3a3-473d-8160-22d583647388")
 		(property "Reference" "L2"
-			(at 910.59 334.0099 0)
+			(at 842.01 384.8099 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -63856,7 +74352,7 @@
 			)
 		)
 		(property "Value" "120nH"
-			(at 910.59 336.5499 0)
+			(at 842.01 387.3499 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -63865,7 +74361,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 911.86 335.28 0)
+			(at 843.28 386.08 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -63874,7 +74370,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 911.86 335.28 0)
+			(at 843.28 386.08 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -63883,7 +74379,7 @@
 			)
 		)
 		(property "Description" "Inductor"
-			(at 911.86 335.28 0)
+			(at 843.28 386.08 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -63908,7 +74404,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 688.34 238.76 0)
+		(at 760.73 238.76 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -63916,8 +74412,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "2ac7f57e-64e2-4c9c-9398-02e13afab807")
-		(property "Reference" "#PWR0115"
-			(at 688.34 245.11 0)
+		(property "Reference" "#PWR115"
+			(at 760.73 245.11 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -63926,7 +74422,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 688.34 243.84 0)
+			(at 760.73 243.84 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -63934,7 +74430,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 688.34 238.76 0)
+			(at 760.73 238.76 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -63943,7 +74439,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 688.34 238.76 0)
+			(at 760.73 238.76 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -63952,7 +74448,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 688.34 238.76 0)
+			(at 760.73 238.76 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -63966,7 +74462,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0115")
+					(reference "#PWR115")
 					(unit 1)
 				)
 			)
@@ -64043,7 +74539,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 789.94 322.58 0)
+		(at 687.07 322.58 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -64052,7 +74548,7 @@
 		(fields_autoplaced yes)
 		(uuid "2b59e5f4-b824-452e-8aa8-c64c7738cd37")
 		(property "Reference" "C142"
-			(at 793.75 321.3099 0)
+			(at 690.88 321.3099 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -64061,7 +74557,7 @@
 			)
 		)
 		(property "Value" "0.1uF"
-			(at 793.75 323.8499 0)
+			(at 690.88 323.8499 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -64070,7 +74566,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 790.9052 326.39 0)
+			(at 688.0352 326.39 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -64079,7 +74575,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 789.94 322.58 0)
+			(at 687.07 322.58 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -64088,7 +74584,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 789.94 322.58 0)
+			(at 687.07 322.58 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -64180,7 +74676,7 @@
 	)
 	(symbol
 		(lib_id "Device:L")
-		(at 570.23 316.23 270)
+		(at 523.24 373.38 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -64188,7 +74684,7 @@
 		(dnp no)
 		(uuid "2d2ab62b-4a63-409a-894f-160d0a159aab")
 		(property "Reference" "L6"
-			(at 570.23 312.42 90)
+			(at 523.24 369.57 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -64196,7 +74692,7 @@
 			)
 		)
 		(property "Value" "27uH"
-			(at 570.23 314.452 90)
+			(at 523.24 371.602 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -64204,7 +74700,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 570.23 316.23 0)
+			(at 523.24 373.38 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -64213,7 +74709,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 570.23 316.23 0)
+			(at 523.24 373.38 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -64222,7 +74718,7 @@
 			)
 		)
 		(property "Description" "Inductor"
-			(at 570.23 316.23 0)
+			(at 523.24 373.38 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -64452,7 +74948,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 675.64 261.62 0)
+		(at 748.03 261.62 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -64460,7 +74956,7 @@
 		(dnp no)
 		(uuid "2e6ed5d5-e737-441c-ab44-3fe633661e9f")
 		(property "Reference" "C86"
-			(at 668.782 259.588 0)
+			(at 741.172 259.588 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -64469,7 +74965,7 @@
 			)
 		)
 		(property "Value" "10pF"
-			(at 668.782 262.128 0)
+			(at 741.172 262.128 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -64478,7 +74974,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 676.6052 265.43 0)
+			(at 748.9952 265.43 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -64487,7 +74983,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 675.64 261.62 0)
+			(at 748.03 261.62 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -64496,7 +74992,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 675.64 261.62 0)
+			(at 748.03 261.62 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -64596,7 +75092,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "2ed68fa3-f984-4afd-8f29-f5f0dee15809")
-		(property "Reference" "#PWR035"
+		(property "Reference" "#PWR35"
 			(at 318.77 373.38 0)
 			(effects
 				(font
@@ -64647,7 +75143,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR035")
+					(reference "#PWR35")
 					(unit 1)
 				)
 			)
@@ -64722,7 +75218,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 814.07 334.01 0)
+		(at 711.2 334.01 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -64730,7 +75226,7 @@
 		(dnp no)
 		(uuid "2ee8aede-1b9e-4584-b4ae-27ac2125f931")
 		(property "Reference" "C146"
-			(at 808.736 331.978 0)
+			(at 705.866 331.978 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -64739,7 +75235,7 @@
 			)
 		)
 		(property "Value" "4.7pF"
-			(at 814.324 331.978 0)
+			(at 711.454 331.978 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -64748,7 +75244,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 815.0352 337.82 0)
+			(at 712.1652 337.82 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -64757,7 +75253,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 814.07 334.01 0)
+			(at 711.2 334.01 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -64766,7 +75262,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 814.07 334.01 0)
+			(at 711.2 334.01 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -64865,7 +75361,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 627.38 193.04 270)
+		(at 699.77 193.04 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -64874,7 +75370,7 @@
 		(fields_autoplaced yes)
 		(uuid "2f698652-cde1-49a4-a941-bdfc16c16400")
 		(property "Reference" "C56"
-			(at 627.38 185.42 90)
+			(at 699.77 185.42 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -64882,7 +75378,7 @@
 			)
 		)
 		(property "Value" "1uF"
-			(at 627.38 187.96 90)
+			(at 699.77 187.96 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -64890,7 +75386,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 623.57 194.0052 0)
+			(at 695.96 194.0052 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -64899,7 +75395,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 627.38 193.04 0)
+			(at 699.77 193.04 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -64908,7 +75404,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 627.38 193.04 0)
+			(at 699.77 193.04 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -65039,7 +75535,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 416.56 377.19 0)
+		(at 374.65 402.59 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -65047,7 +75543,7 @@
 		(dnp no)
 		(uuid "2ffceb49-414c-4f0b-9c67-203a460d10e0")
 		(property "Reference" "C123"
-			(at 420.37 375.9199 0)
+			(at 378.46 401.3199 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -65056,7 +75552,7 @@
 			)
 		)
 		(property "Value" "0.1uF"
-			(at 420.37 378.4599 0)
+			(at 378.46 403.8599 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -65065,7 +75561,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 417.5252 381 0)
+			(at 375.6152 406.4 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -65074,7 +75570,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 416.56 377.19 0)
+			(at 374.65 402.59 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -65083,7 +75579,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 416.56 377.19 0)
+			(at 374.65 402.59 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -65178,7 +75674,7 @@
 	)
 	(symbol
 		(lib_id "Device:L")
-		(at 582.93 354.33 270)
+		(at 535.94 411.48 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -65187,7 +75683,7 @@
 		(fields_autoplaced yes)
 		(uuid "30d7bde3-5037-4c0f-8b87-395c3349f30a")
 		(property "Reference" "L8"
-			(at 582.93 359.41 90)
+			(at 535.94 416.56 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -65195,7 +75691,7 @@
 			)
 		)
 		(property "Value" "27uH"
-			(at 582.93 356.87 90)
+			(at 535.94 414.02 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -65203,7 +75699,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 582.93 354.33 0)
+			(at 535.94 411.48 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -65212,7 +75708,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 582.93 354.33 0)
+			(at 535.94 411.48 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -65221,7 +75717,7 @@
 			)
 		)
 		(property "Description" "Inductor"
-			(at 582.93 354.33 0)
+			(at 535.94 411.48 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -65254,7 +75750,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "30f51bac-59ad-4210-ae77-f5ef3a00f1b1")
-		(property "Reference" "#PWR067"
+		(property "Reference" "#PWR67"
 			(at 872.49 632.46 0)
 			(effects
 				(font
@@ -65304,7 +75800,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR067")
+					(reference "#PWR67")
 					(unit 1)
 				)
 			)
@@ -65450,7 +75946,7 @@
 	)
 	(symbol
 		(lib_id "Device:L")
-		(at 557.53 316.23 270)
+		(at 510.54 373.38 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -65458,7 +75954,7 @@
 		(dnp no)
 		(uuid "31109ca8-32e9-44b8-a1e5-904a3141cc19")
 		(property "Reference" "L11"
-			(at 557.53 312.42 90)
+			(at 510.54 369.57 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -65466,7 +75962,7 @@
 			)
 		)
 		(property "Value" "10uH"
-			(at 557.53 314.452 90)
+			(at 510.54 371.602 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -65474,7 +75970,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 557.53 316.23 0)
+			(at 510.54 373.38 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -65483,7 +75979,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 557.53 316.23 0)
+			(at 510.54 373.38 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -65492,7 +75988,7 @@
 			)
 		)
 		(property "Description" "Inductor"
-			(at 557.53 316.23 0)
+			(at 510.54 373.38 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -65517,7 +76013,7 @@
 	)
 	(symbol
 		(lib_id "power:+3V3")
-		(at 415.29 346.71 90)
+		(at 373.38 372.11 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -65526,7 +76022,7 @@
 		(fields_autoplaced yes)
 		(uuid "3171a924-147f-48d1-81a7-dca752cc037f")
 		(property "Reference" "#PWR0330"
-			(at 419.1 346.71 0)
+			(at 377.19 372.11 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -65535,7 +76031,7 @@
 			)
 		)
 		(property "Value" "+1V"
-			(at 411.48 346.7099 90)
+			(at 369.57 372.1099 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -65544,7 +76040,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 415.29 346.71 0)
+			(at 373.38 372.11 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -65553,7 +76049,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 415.29 346.71 0)
+			(at 373.38 372.11 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -65562,7 +76058,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"+3V3\""
-			(at 415.29 346.71 0)
+			(at 373.38 372.11 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -65584,7 +76080,7 @@
 	)
 	(symbol
 		(lib_id "power:+5V")
-		(at 712.47 330.2 270)
+		(at 642.62 384.81 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -65593,7 +76089,7 @@
 		(fields_autoplaced yes)
 		(uuid "31a41163-ae37-4f49-a87d-503cc4d03cae")
 		(property "Reference" "#PWR0268"
-			(at 708.66 330.2 0)
+			(at 638.81 384.81 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -65602,7 +76098,7 @@
 			)
 		)
 		(property "Value" "+5V"
-			(at 716.28 330.1999 90)
+			(at 646.43 384.8099 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -65611,7 +76107,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 712.47 330.2 0)
+			(at 642.62 384.81 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -65620,7 +76116,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 712.47 330.2 0)
+			(at 642.62 384.81 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -65629,7 +76125,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"+5V\""
-			(at 712.47 330.2 0)
+			(at 642.62 384.81 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -65651,7 +76147,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 554.99 389.89 0)
+		(at 674.37 378.46 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -65659,7 +76155,7 @@
 		(dnp no)
 		(uuid "31b772cb-3969-40f7-9653-0265d1313d45")
 		(property "Reference" "C47"
-			(at 548.64 388.874 0)
+			(at 668.02 377.444 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -65668,7 +76164,7 @@
 			)
 		)
 		(property "Value" ".1uF"
-			(at 548.132 391.16 0)
+			(at 667.512 379.73 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -65677,7 +76173,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 555.9552 393.7 0)
+			(at 675.3352 382.27 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -65686,7 +76182,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 554.99 389.89 0)
+			(at 674.37 378.46 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -65695,7 +76191,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 554.99 389.89 0)
+			(at 674.37 378.46 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -65934,7 +76430,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "3415c61b-aed8-4dc0-93ec-83de7c263f95")
-		(property "Reference" "#PWR0208"
+		(property "Reference" "#PWR208"
 			(at 97.79 737.87 0)
 			(effects
 				(font
@@ -65984,7 +76480,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0208")
+					(reference "#PWR208")
 					(unit 1)
 				)
 			)
@@ -66000,7 +76496,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "341c2d9a-661a-4ad6-9699-7bfe53695c6e")
-		(property "Reference" "#PWR043"
+		(property "Reference" "#PWR43"
 			(at 222.25 262.89 0)
 			(effects
 				(font
@@ -66051,7 +76547,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR043")
+					(reference "#PWR43")
 					(unit 1)
 				)
 			)
@@ -66067,7 +76563,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "343e7201-b01b-4212-b615-418ccd936ffb")
-		(property "Reference" "#PWR0214"
+		(property "Reference" "#PWR214"
 			(at 222.25 637.54 0)
 			(effects
 				(font
@@ -66118,7 +76614,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0214")
+					(reference "#PWR214")
 					(unit 1)
 				)
 			)
@@ -66134,7 +76630,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "344f10cd-a542-473a-8a8f-47f9b933f60a")
-		(property "Reference" "#PWR060"
+		(property "Reference" "#PWR60"
 			(at 792.48 638.81 0)
 			(effects
 				(font
@@ -66185,7 +76681,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR060")
+					(reference "#PWR60")
 					(unit 1)
 				)
 			)
@@ -66201,7 +76697,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "34cebe48-5d43-4722-8d0b-c92121114147")
-		(property "Reference" "#PWR0220"
+		(property "Reference" "#PWR220"
 			(at 223.52 581.66 0)
 			(effects
 				(font
@@ -66251,7 +76747,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0220")
+					(reference "#PWR220")
 					(unit 1)
 				)
 			)
@@ -66458,7 +76954,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 982.98 341.63 270)
+		(at 914.4 392.43 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -66466,8 +76962,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "36322850-66e4-47d1-bb27-e6b6bfc285a1")
-		(property "Reference" "#PWR032"
-			(at 976.63 341.63 0)
+		(property "Reference" "#PWR32"
+			(at 908.05 392.43 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -66476,7 +76972,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 979.17 341.6299 90)
+			(at 910.59 392.4299 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -66485,7 +76981,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 982.98 341.63 0)
+			(at 914.4 392.43 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -66494,7 +76990,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 982.98 341.63 0)
+			(at 914.4 392.43 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -66503,7 +76999,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 982.98 341.63 0)
+			(at 914.4 392.43 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -66517,7 +77013,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR032")
+					(reference "#PWR32")
 					(unit 1)
 				)
 			)
@@ -66533,7 +77029,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "36459063-32ea-4199-9ebf-26df7cb2f9bf")
-		(property "Reference" "#PWR0218"
+		(property "Reference" "#PWR218"
 			(at 154.94 586.74 0)
 			(effects
 				(font
@@ -66583,7 +77079,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0218")
+					(reference "#PWR218")
 					(unit 1)
 				)
 			)
@@ -66661,7 +77157,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 491.49 383.54 0)
+		(at 449.58 408.94 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -66669,8 +77165,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "36860bde-1d82-46a0-ab31-caa03c91d571")
-		(property "Reference" "#PWR0286"
-			(at 491.49 389.89 0)
+		(property "Reference" "#PWR286"
+			(at 449.58 415.29 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -66679,7 +77175,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 491.49 388.62 0)
+			(at 449.58 414.02 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -66688,7 +77184,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 491.49 383.54 0)
+			(at 449.58 408.94 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -66697,7 +77193,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 491.49 383.54 0)
+			(at 449.58 408.94 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -66706,7 +77202,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 491.49 383.54 0)
+			(at 449.58 408.94 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -66720,7 +77216,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0286")
+					(reference "#PWR286")
 					(unit 1)
 				)
 			)
@@ -66938,7 +77434,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "376a01c9-8af3-46d3-8496-f3ff1a4ab595")
-		(property "Reference" "#PWR0206"
+		(property "Reference" "#PWR206"
 			(at 40.64 740.41 0)
 			(effects
 				(font
@@ -66988,7 +77484,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0206")
+					(reference "#PWR206")
 					(unit 1)
 				)
 			)
@@ -67140,7 +77636,7 @@
 	)
 	(symbol
 		(lib_id "Device:L")
-		(at 778.51 342.9 0)
+		(at 675.64 342.9 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -67149,7 +77645,7 @@
 		(fields_autoplaced yes)
 		(uuid "381b2054-9ec5-43c2-878e-4be52eb25c9f")
 		(property "Reference" "L27"
-			(at 779.78 341.6299 0)
+			(at 676.91 341.6299 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -67158,7 +77654,7 @@
 			)
 		)
 		(property "Value" "19nH"
-			(at 779.78 344.1699 0)
+			(at 676.91 344.1699 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -67167,7 +77663,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 778.51 342.9 0)
+			(at 675.64 342.9 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -67176,7 +77672,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 778.51 342.9 0)
+			(at 675.64 342.9 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -67185,7 +77681,7 @@
 			)
 		)
 		(property "Description" "Inductor"
-			(at 778.51 342.9 0)
+			(at 675.64 342.9 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -67210,7 +77706,7 @@
 	)
 	(symbol
 		(lib_id "power:+3V3")
-		(at 778.51 309.88 0)
+		(at 675.64 309.88 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -67219,7 +77715,7 @@
 		(fields_autoplaced yes)
 		(uuid "3858eb77-5d2a-48c7-9507-f611b1d53763")
 		(property "Reference" "#PWR0312"
-			(at 778.51 313.69 0)
+			(at 675.64 313.69 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -67228,7 +77724,7 @@
 			)
 		)
 		(property "Value" "+3V3"
-			(at 778.51 304.8 0)
+			(at 675.64 304.8 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -67236,7 +77732,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 778.51 309.88 0)
+			(at 675.64 309.88 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -67245,7 +77741,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 778.51 309.88 0)
+			(at 675.64 309.88 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -67254,7 +77750,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"+3V3\""
-			(at 778.51 309.88 0)
+			(at 675.64 309.88 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -67284,7 +77780,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "38fcf87b-a3af-4757-ad58-6c045a9212e9")
-		(property "Reference" "#PWR0207"
+		(property "Reference" "#PWR207"
 			(at 57.15 717.55 0)
 			(effects
 				(font
@@ -67334,7 +77830,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0207")
+					(reference "#PWR207")
 					(unit 1)
 				)
 			)
@@ -67350,7 +77846,7 @@
 		(on_board yes)
 		(dnp no)
 		(uuid "3926283a-9c52-4e59-9569-35530aa00dd0")
-		(property "Reference" "#PWR0216"
+		(property "Reference" "#PWR216"
 			(at 289.56 648.97 0)
 			(effects
 				(font
@@ -67400,7 +77896,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0216")
+					(reference "#PWR216")
 					(unit 1)
 				)
 			)
@@ -67817,7 +78313,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 480.06 360.68 90)
+		(at 438.15 386.08 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -67825,8 +78321,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "3b89f01a-c8ac-4223-af76-63760bc580ee")
-		(property "Reference" "#PWR049"
-			(at 486.41 360.68 0)
+		(property "Reference" "#PWR49"
+			(at 444.5 386.08 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -67835,7 +78331,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 483.87 360.6799 90)
+			(at 441.96 386.0799 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -67845,7 +78341,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 480.06 360.68 0)
+			(at 438.15 386.08 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -67854,7 +78350,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 480.06 360.68 0)
+			(at 438.15 386.08 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -67863,7 +78359,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 480.06 360.68 0)
+			(at 438.15 386.08 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -67877,7 +78373,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR049")
+					(reference "#PWR49")
 					(unit 1)
 				)
 			)
@@ -67885,7 +78381,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 416.56 381 0)
+		(at 374.65 406.4 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -67893,8 +78389,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "3ba7325e-c730-4eb2-9451-ee278d986dca")
-		(property "Reference" "#PWR0290"
-			(at 416.56 387.35 0)
+		(property "Reference" "#PWR290"
+			(at 374.65 412.75 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -67903,7 +78399,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 416.56 386.08 0)
+			(at 374.65 411.48 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -67912,7 +78408,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 416.56 381 0)
+			(at 374.65 406.4 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -67921,7 +78417,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 416.56 381 0)
+			(at 374.65 406.4 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -67930,7 +78426,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 416.56 381 0)
+			(at 374.65 406.4 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -67944,7 +78440,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0290")
+					(reference "#PWR290")
 					(unit 1)
 				)
 			)
@@ -68030,7 +78526,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "3cbf7a47-63d8-4e2d-b9d0-fdf9b91f8e95")
-		(property "Reference" "#PWR0173"
+		(property "Reference" "#PWR173"
 			(at 152.4 115.57 0)
 			(effects
 				(font
@@ -68080,7 +78576,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0173")
+					(reference "#PWR173")
 					(unit 1)
 				)
 			)
@@ -68096,7 +78592,7 @@
 		(on_board yes)
 		(dnp no)
 		(uuid "3cc87c5a-dffd-458f-b28f-22d5161c4d77")
-		(property "Reference" "#PWR080"
+		(property "Reference" "#PWR80"
 			(at 50.8 694.69 0)
 			(effects
 				(font
@@ -68147,7 +78643,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR080")
+					(reference "#PWR80")
 					(unit 1)
 				)
 			)
@@ -68230,7 +78726,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "3dbc7e17-da75-46b0-bef8-828699a2f8df")
-		(property "Reference" "#PWR0219"
+		(property "Reference" "#PWR219"
 			(at 209.55 598.17 0)
 			(effects
 				(font
@@ -68281,7 +78777,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0219")
+					(reference "#PWR219")
 					(unit 1)
 				)
 			)
@@ -68493,7 +78989,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 1021.08 341.63 90)
+		(at 952.5 392.43 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -68501,8 +78997,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "3edf554b-d45c-4b6d-9429-64a24ae3c824")
-		(property "Reference" "#PWR030"
-			(at 1027.43 341.63 0)
+		(property "Reference" "#PWR30"
+			(at 958.85 392.43 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -68511,7 +79007,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 1024.89 341.6299 90)
+			(at 956.31 392.4299 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -68520,7 +79016,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 1021.08 341.63 0)
+			(at 952.5 392.43 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -68529,7 +79025,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 1021.08 341.63 0)
+			(at 952.5 392.43 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -68538,7 +79034,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 1021.08 341.63 0)
+			(at 952.5 392.43 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -68552,7 +79048,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR030")
+					(reference "#PWR30")
 					(unit 1)
 				)
 			)
@@ -68569,7 +79065,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "3f04eef1-2624-41a7-a1f3-d8bb623c471e")
-		(property "Reference" "#PWR0337"
+		(property "Reference" "#PWR337"
 			(at 137.16 349.25 0)
 			(effects
 				(font
@@ -68619,7 +79115,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0337")
+					(reference "#PWR337")
 					(unit 1)
 				)
 			)
@@ -68696,7 +79192,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 834.39 330.2 180)
+		(at 731.52 330.2 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -68704,8 +79200,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "4083a888-6754-4e89-9d40-8f8b9e9b8cce")
-		(property "Reference" "#PWR0319"
-			(at 834.39 323.85 0)
+		(property "Reference" "#PWR319"
+			(at 731.52 323.85 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -68714,7 +79210,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 834.39 325.12 0)
+			(at 731.52 325.12 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -68723,7 +79219,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 834.39 330.2 0)
+			(at 731.52 330.2 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -68732,7 +79228,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 834.39 330.2 0)
+			(at 731.52 330.2 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -68741,7 +79237,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 834.39 330.2 0)
+			(at 731.52 330.2 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -68755,7 +79251,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0319")
+					(reference "#PWR319")
 					(unit 1)
 				)
 			)
@@ -68833,7 +79329,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 441.96 325.12 180)
+		(at 400.05 350.52 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -68841,7 +79337,7 @@
 		(dnp no)
 		(uuid "4146ff6f-b89b-476d-8b44-a6e9d4fe66d0")
 		(property "Reference" "C1"
-			(at 438.15 326.3901 0)
+			(at 396.24 351.7901 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -68850,7 +79346,7 @@
 			)
 		)
 		(property "Value" "0.1uF"
-			(at 438.15 323.8501 0)
+			(at 396.24 349.2501 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -68859,7 +79355,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 440.9948 321.31 0)
+			(at 399.0848 346.71 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -68868,7 +79364,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 441.96 325.12 0)
+			(at 400.05 350.52 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -68877,7 +79373,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 441.96 325.12 0)
+			(at 400.05 350.52 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -68910,7 +79406,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "42957b84-f3eb-4e9e-a5f9-c6060ae99e94")
-		(property "Reference" "#PWR0304"
+		(property "Reference" "#PWR304"
 			(at 420.37 182.88 0)
 			(effects
 				(font
@@ -68961,7 +79457,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0304")
+					(reference "#PWR304")
 					(unit 1)
 				)
 			)
@@ -68977,7 +79473,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "42ff5903-3130-47c8-b5f3-3948367964eb")
-		(property "Reference" "#PWR020"
+		(property "Reference" "#PWR20"
 			(at 909.32 140.97 0)
 			(effects
 				(font
@@ -69028,7 +79524,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR020")
+					(reference "#PWR20")
 					(unit 1)
 				)
 			)
@@ -69036,7 +79532,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 508 233.68 90)
+		(at 605.79 267.97 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -69045,7 +79541,7 @@
 		(fields_autoplaced yes)
 		(uuid "435533bd-460d-4271-8335-ea02be42c8b4")
 		(property "Reference" "C83"
-			(at 508 226.06 90)
+			(at 605.79 260.35 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -69053,7 +79549,7 @@
 			)
 		)
 		(property "Value" "1nF"
-			(at 508 228.6 90)
+			(at 605.79 262.89 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -69061,7 +79557,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 511.81 232.7148 0)
+			(at 609.6 267.0048 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -69070,7 +79566,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 508 233.68 0)
+			(at 605.79 267.97 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -69079,7 +79575,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 508 233.68 0)
+			(at 605.79 267.97 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -69104,7 +79600,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 659.13 259.08 0)
+		(at 731.52 259.08 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -69112,8 +79608,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "43b05fcc-13a3-45cc-b85b-f78fccb0e3c5")
-		(property "Reference" "#PWR0142"
-			(at 659.13 265.43 0)
+		(property "Reference" "#PWR142"
+			(at 731.52 265.43 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -69122,7 +79618,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 659.13 264.16 0)
+			(at 731.52 264.16 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -69130,7 +79626,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 659.13 259.08 0)
+			(at 731.52 259.08 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -69139,7 +79635,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 659.13 259.08 0)
+			(at 731.52 259.08 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -69148,7 +79644,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 659.13 259.08 0)
+			(at 731.52 259.08 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -69162,7 +79658,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0142")
+					(reference "#PWR142")
 					(unit 1)
 				)
 			)
@@ -69247,7 +79743,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "43e8a556-ea2a-44f0-ba99-f4fc5e815df4")
-		(property "Reference" "#PWR0189"
+		(property "Reference" "#PWR189"
 			(at 149.86 736.6 0)
 			(effects
 				(font
@@ -69297,7 +79793,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0189")
+					(reference "#PWR189")
 					(unit 1)
 				)
 			)
@@ -69305,7 +79801,7 @@
 	)
 	(symbol
 		(lib_id "LIB_IRISHSAT:B39921B2672P810")
-		(at 1132.84 339.09 0)
+		(at 1064.26 389.89 0)
 		(mirror y)
 		(unit 1)
 		(exclude_from_sim no)
@@ -69315,7 +79811,7 @@
 		(fields_autoplaced yes)
 		(uuid "43f037db-fc1e-4cef-b2fe-70a7283e46e4")
 		(property "Reference" "FL4"
-			(at 1113.79 331.47 0)
+			(at 1045.21 382.27 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -69323,7 +79819,7 @@
 			)
 		)
 		(property "Value" "B39921B2672P810"
-			(at 1113.79 334.01 0)
+			(at 1045.21 384.81 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -69331,7 +79827,7 @@
 			)
 		)
 		(property "Footprint" "LIB_IRISHSAT:B39921B2672P810"
-			(at 1098.55 434.01 0)
+			(at 1029.97 484.81 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -69341,7 +79837,7 @@
 			)
 		)
 		(property "Datasheet" "https://componentsearchengine.com/Datasheets/1/B39921B2672P810.pdf"
-			(at 1098.55 534.01 0)
+			(at 1029.97 584.81 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -69351,7 +79847,7 @@
 			)
 		)
 		(property "Description" "Signal Conditioning 50ohm 26MHz CSSP3 GT"
-			(at 1132.84 339.09 0)
+			(at 1064.26 389.89 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -69360,7 +79856,7 @@
 			)
 		)
 		(property "Height" "0.45"
-			(at 1098.55 734.01 0)
+			(at 1029.97 784.81 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -69370,7 +79866,7 @@
 			)
 		)
 		(property "Mouser Part Number" "871-B39921B2672P810"
-			(at 1098.55 834.01 0)
+			(at 1029.97 884.81 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -69380,7 +79876,7 @@
 			)
 		)
 		(property "Mouser Price/Stock" "https://www.mouser.co.uk/ProductDetail/RF360/B39921B2672P810?qs=bZr6mbWTK5kdVCepanD%252BhQ%3D%3D"
-			(at 1098.55 934.01 0)
+			(at 1029.97 984.81 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -69390,7 +79886,7 @@
 			)
 		)
 		(property "Manufacturer_Name" "RF360"
-			(at 1098.55 1034.01 0)
+			(at 1029.97 1084.81 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -69400,7 +79896,7 @@
 			)
 		)
 		(property "Manufacturer_Part_Number" "B39921B2672P810"
-			(at 1098.55 1134.01 0)
+			(at 1029.97 1184.81 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -69502,7 +79998,7 @@
 	)
 	(symbol
 		(lib_id "Device:L")
-		(at 582.93 341.63 270)
+		(at 535.94 398.78 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -69510,7 +80006,7 @@
 		(dnp no)
 		(uuid "44981fd2-e2f2-4e31-955c-4f25bcecdfaf")
 		(property "Reference" "L5"
-			(at 582.93 343.662 90)
+			(at 535.94 400.812 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -69518,7 +80014,7 @@
 			)
 		)
 		(property "Value" "27uH"
-			(at 582.93 339.852 90)
+			(at 535.94 397.002 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -69526,7 +80022,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 582.93 341.63 0)
+			(at 535.94 398.78 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -69535,7 +80031,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 582.93 341.63 0)
+			(at 535.94 398.78 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -69544,7 +80040,7 @@
 			)
 		)
 		(property "Description" "Inductor"
-			(at 582.93 341.63 0)
+			(at 535.94 398.78 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -69569,7 +80065,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 657.86 414.02 0)
+		(at 777.24 402.59 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -69577,8 +80073,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "44e8b5c4-94b0-415e-a760-ca3f2b6cce1e")
-		(property "Reference" "#PWR0133"
-			(at 657.86 420.37 0)
+		(property "Reference" "#PWR133"
+			(at 777.24 408.94 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -69587,7 +80083,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 657.86 419.1 0)
+			(at 777.24 407.67 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -69596,7 +80092,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 657.86 414.02 0)
+			(at 777.24 402.59 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -69605,7 +80101,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 657.86 414.02 0)
+			(at 777.24 402.59 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -69614,7 +80110,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 657.86 414.02 0)
+			(at 777.24 402.59 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -69628,7 +80124,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0133")
+					(reference "#PWR133")
 					(unit 1)
 				)
 			)
@@ -69636,7 +80132,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 763.27 316.23 0)
+		(at 660.4 316.23 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -69645,7 +80141,7 @@
 		(fields_autoplaced yes)
 		(uuid "451b7de7-9d47-4efe-b73c-4628aef3dc21")
 		(property "Reference" "C141"
-			(at 767.08 314.9599 0)
+			(at 664.21 314.9599 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -69654,7 +80150,7 @@
 			)
 		)
 		(property "Value" "120pF"
-			(at 767.08 317.4999 0)
+			(at 664.21 317.4999 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -69663,7 +80159,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 764.2352 320.04 0)
+			(at 661.3652 320.04 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -69672,7 +80168,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 763.27 316.23 0)
+			(at 660.4 316.23 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -69681,7 +80177,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 763.27 316.23 0)
+			(at 660.4 316.23 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -69706,7 +80202,7 @@
 	)
 	(symbol
 		(lib_id "power:+5V")
-		(at 551.18 400.05 0)
+		(at 670.56 388.62 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -69714,7 +80210,7 @@
 		(dnp no)
 		(uuid "4555c6d5-12cd-4794-83a1-27d8112f49ed")
 		(property "Reference" "#PWR0123"
-			(at 551.18 403.86 0)
+			(at 670.56 392.43 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -69723,7 +80219,7 @@
 			)
 		)
 		(property "Value" "+5V"
-			(at 551.18 396.24 0)
+			(at 670.56 384.81 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -69731,7 +80227,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 551.18 400.05 0)
+			(at 670.56 388.62 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -69740,7 +80236,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 551.18 400.05 0)
+			(at 670.56 388.62 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -69749,7 +80245,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"+5V\""
-			(at 551.18 400.05 0)
+			(at 670.56 388.62 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -69927,7 +80423,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 421.64 351.79 90)
+		(at 379.73 377.19 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -69935,7 +80431,7 @@
 		(dnp no)
 		(uuid "46823891-b6a2-4e34-81e9-56c9d0542fc2")
 		(property "Reference" "C153"
-			(at 419.608 348.234 90)
+			(at 377.698 373.634 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -69944,7 +80440,7 @@
 			)
 		)
 		(property "Value" ".1uF"
-			(at 419.862 355.346 90)
+			(at 377.952 380.746 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -69953,7 +80449,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 425.45 350.8248 0)
+			(at 383.54 376.2248 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -69962,7 +80458,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 421.64 351.79 0)
+			(at 379.73 377.19 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -69971,7 +80467,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 421.64 351.79 0)
+			(at 379.73 377.19 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -70004,7 +80500,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "4690f78d-5e79-4326-b42c-0b2698a21f70")
-		(property "Reference" "#PWR0271"
+		(property "Reference" "#PWR271"
 			(at 582.93 132.08 0)
 			(effects
 				(font
@@ -70055,7 +80551,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0271")
+					(reference "#PWR271")
 					(unit 1)
 				)
 			)
@@ -70141,7 +80637,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "47238395-80de-4031-ac58-317bc5199789")
-		(property "Reference" "#PWR0340"
+		(property "Reference" "#PWR340"
 			(at 222.25 224.79 0)
 			(effects
 				(font
@@ -70192,7 +80688,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0340")
+					(reference "#PWR340")
 					(unit 1)
 				)
 			)
@@ -70200,7 +80696,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 678.18 265.43 0)
+		(at 750.57 265.43 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -70208,8 +80704,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "47d802c8-102f-4106-884f-9a8653bfd0f4")
-		(property "Reference" "#PWR0237"
-			(at 678.18 271.78 0)
+		(property "Reference" "#PWR237"
+			(at 750.57 271.78 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -70218,7 +80714,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 678.18 270.51 0)
+			(at 750.57 270.51 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -70226,7 +80722,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 678.18 265.43 0)
+			(at 750.57 265.43 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -70235,7 +80731,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 678.18 265.43 0)
+			(at 750.57 265.43 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -70244,7 +80740,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 678.18 265.43 0)
+			(at 750.57 265.43 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -70258,7 +80754,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0237")
+					(reference "#PWR237")
 					(unit 1)
 				)
 			)
@@ -70401,7 +80897,7 @@
 	)
 	(symbol
 		(lib_id "Device:L")
-		(at 781.05 322.58 0)
+		(at 678.18 322.58 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -70410,7 +80906,7 @@
 		(fields_autoplaced yes)
 		(uuid "4910a8a8-80d0-4a6e-9fe4-d22705fa1b0c")
 		(property "Reference" "L28"
-			(at 782.32 321.3099 0)
+			(at 679.45 321.3099 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -70419,7 +80915,7 @@
 			)
 		)
 		(property "Value" "19nH"
-			(at 782.32 323.8499 0)
+			(at 679.45 323.8499 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -70428,7 +80924,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 781.05 322.58 0)
+			(at 678.18 322.58 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -70437,7 +80933,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 781.05 322.58 0)
+			(at 678.18 322.58 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -70446,7 +80942,7 @@
 			)
 		)
 		(property "Description" "Inductor"
-			(at 781.05 322.58 0)
+			(at 678.18 322.58 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -70471,7 +80967,7 @@
 	)
 	(symbol
 		(lib_id "power:+5V")
-		(at 657.86 406.4 0)
+		(at 777.24 394.97 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -70479,7 +80975,7 @@
 		(dnp no)
 		(uuid "4913a217-a196-47fa-a306-39e3424990c6")
 		(property "Reference" "#PWR0132"
-			(at 657.86 410.21 0)
+			(at 777.24 398.78 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -70488,7 +80984,7 @@
 			)
 		)
 		(property "Value" "+5V"
-			(at 657.86 402.59 0)
+			(at 777.24 391.16 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -70496,7 +80992,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 657.86 406.4 0)
+			(at 777.24 394.97 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -70505,7 +81001,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 657.86 406.4 0)
+			(at 777.24 394.97 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -70514,7 +81010,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"+5V\""
-			(at 657.86 406.4 0)
+			(at 777.24 394.97 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -70614,7 +81110,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "4960fdff-cc0f-4931-aaae-448ec7ebca14")
-		(property "Reference" "#PWR0306"
+		(property "Reference" "#PWR306"
 			(at 137.16 58.42 0)
 			(effects
 				(font
@@ -70665,7 +81161,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0306")
+					(reference "#PWR306")
 					(unit 1)
 				)
 			)
@@ -70743,7 +81239,7 @@
 	)
 	(symbol
 		(lib_id "LIB_IRISHSAT:DSC1001CI2-100.0000T")
-		(at 454.66 231.14 0)
+		(at 552.45 265.43 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -70752,7 +81248,7 @@
 		(fields_autoplaced yes)
 		(uuid "49e2f6ef-6167-4e5b-8c93-de598bb67670")
 		(property "Reference" "U14"
-			(at 477.52 220.98 0)
+			(at 575.31 255.27 0)
 			(effects
 				(font
 					(size 1.524 1.524)
@@ -70760,7 +81256,7 @@
 			)
 		)
 		(property "Value" "DSC1001CI2-100.0000T"
-			(at 477.52 223.52 0)
+			(at 575.31 257.81 0)
 			(effects
 				(font
 					(size 1.524 1.524)
@@ -70768,7 +81264,7 @@
 			)
 		)
 		(property "Footprint" "LIB_IRISHSAT:CDFN4_3P2X2P5_MCH"
-			(at 454.66 231.14 0)
+			(at 552.45 265.43 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -70778,7 +81274,7 @@
 			)
 		)
 		(property "Datasheet" "DSC1001CI2-100.0000T"
-			(at 454.66 231.14 0)
+			(at 552.45 265.43 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -70788,7 +81284,7 @@
 			)
 		)
 		(property "Description" ""
-			(at 454.66 231.14 0)
+			(at 552.45 265.43 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -70827,7 +81323,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "4ac8dc31-13cc-4e80-ace3-3c5daf88428d")
-		(property "Reference" "#PWR0149"
+		(property "Reference" "#PWR149"
 			(at 852.17 151.13 0)
 			(effects
 				(font
@@ -70878,7 +81374,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0149")
+					(reference "#PWR149")
 					(unit 1)
 				)
 			)
@@ -72000,7 +82496,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "4bf54791-e19b-4c2f-8527-98697b6206d3")
-		(property "Reference" "#PWR0170"
+		(property "Reference" "#PWR170"
 			(at 74.93 137.16 0)
 			(effects
 				(font
@@ -72051,7 +82547,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0170")
+					(reference "#PWR170")
 					(unit 1)
 				)
 			)
@@ -72274,7 +82770,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "4d3cfdc8-a8ea-4a3b-be78-e456b327224c")
-		(property "Reference" "#PWR059"
+		(property "Reference" "#PWR59"
 			(at 972.82 678.18 0)
 			(effects
 				(font
@@ -72324,7 +82820,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR059")
+					(reference "#PWR59")
 					(unit 1)
 				)
 			)
@@ -72332,7 +82828,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 844.55 347.98 90)
+		(at 741.68 347.98 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -72340,7 +82836,7 @@
 		(dnp no)
 		(uuid "4d9d7f69-4f77-4e66-913c-34bf9e9cff2a")
 		(property "Reference" "C151"
-			(at 844.55 351.282 90)
+			(at 741.68 351.282 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -72348,7 +82844,7 @@
 			)
 		)
 		(property "Value" "1nF"
-			(at 844.55 353.822 90)
+			(at 741.68 353.822 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -72356,7 +82852,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 848.36 347.0148 0)
+			(at 745.49 347.0148 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -72365,7 +82861,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 844.55 347.98 0)
+			(at 741.68 347.98 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -72374,7 +82870,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 844.55 347.98 0)
+			(at 741.68 347.98 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -72399,7 +82895,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 802.64 316.23 0)
+		(at 699.77 316.23 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -72408,7 +82904,7 @@
 		(fields_autoplaced yes)
 		(uuid "4e49cc4c-1ef2-4106-bd5b-3ef9ea3a026f")
 		(property "Reference" "C145"
-			(at 806.45 314.9599 0)
+			(at 703.58 314.9599 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -72417,7 +82913,7 @@
 			)
 		)
 		(property "Value" "120pF"
-			(at 806.45 317.4999 0)
+			(at 703.58 317.4999 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -72426,7 +82922,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 803.6052 320.04 0)
+			(at 700.7352 320.04 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -72435,7 +82931,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 802.64 316.23 0)
+			(at 699.77 316.23 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -72444,7 +82940,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 802.64 316.23 0)
+			(at 699.77 316.23 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -72611,7 +83107,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "516c50ed-ca47-45f2-87a5-d1391c352df7")
-		(property "Reference" "#PWR0100"
+		(property "Reference" "#PWR100"
 			(at 308.61 59.69 0)
 			(effects
 				(font
@@ -72662,7 +83158,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0100")
+					(reference "#PWR100")
 					(unit 1)
 				)
 			)
@@ -72678,7 +83174,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "51a21279-65db-46cb-9ad4-a71f5a14c391")
-		(property "Reference" "#PWR034"
+		(property "Reference" "#PWR34"
 			(at 318.77 340.36 0)
 			(effects
 				(font
@@ -72729,7 +83225,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR034")
+					(reference "#PWR34")
 					(unit 1)
 				)
 			)
@@ -72873,7 +83369,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 539.75 200.66 0)
+		(at 598.17 218.44 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -72881,7 +83377,7 @@
 		(dnp no)
 		(uuid "52c2673b-ae33-4627-aa08-86547b9f0be3")
 		(property "Reference" "C138"
-			(at 543.052 199.39 0)
+			(at 601.472 217.17 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -72890,7 +83386,7 @@
 			)
 		)
 		(property "Value" "2700pF"
-			(at 543.052 201.93 0)
+			(at 601.472 219.71 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -72899,7 +83395,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 540.7152 204.47 0)
+			(at 599.1352 222.25 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -72908,7 +83404,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 539.75 200.66 0)
+			(at 598.17 218.44 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -72917,7 +83413,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 539.75 200.66 0)
+			(at 598.17 218.44 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -72951,7 +83447,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "537cb404-63dc-4945-abba-0f3a68b8d867")
-		(property "Reference" "#PWR0260"
+		(property "Reference" "#PWR260"
 			(at 142.24 271.78 0)
 			(effects
 				(font
@@ -73001,7 +83497,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0260")
+					(reference "#PWR260")
 					(unit 1)
 				)
 			)
@@ -73009,7 +83505,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 581.66 415.29 270)
+		(at 701.04 403.86 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -73017,8 +83513,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "538f3d1b-f30a-4e31-807f-860a47fbc640")
-		(property "Reference" "#PWR0128"
-			(at 575.31 415.29 0)
+		(property "Reference" "#PWR128"
+			(at 694.69 403.86 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -73027,7 +83523,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 577.85 415.2899 90)
+			(at 697.23 403.8599 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -73037,7 +83533,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 581.66 415.29 0)
+			(at 701.04 403.86 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -73046,7 +83542,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 581.66 415.29 0)
+			(at 701.04 403.86 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -73055,7 +83551,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 581.66 415.29 0)
+			(at 701.04 403.86 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -73069,7 +83565,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0128")
+					(reference "#PWR128")
 					(unit 1)
 				)
 			)
@@ -73085,7 +83581,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "53ccf40b-85ed-4834-8111-0f6468e68125")
-		(property "Reference" "#PWR0300"
+		(property "Reference" "#PWR300"
 			(at 419.1 204.47 0)
 			(effects
 				(font
@@ -73136,7 +83632,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0300")
+					(reference "#PWR300")
 					(unit 1)
 				)
 			)
@@ -73152,7 +83648,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "54a0ca8c-0ad2-4c85-9844-b8db84a6e609")
-		(property "Reference" "#PWR096"
+		(property "Reference" "#PWR96"
 			(at 222.25 151.13 0)
 			(effects
 				(font
@@ -73203,7 +83699,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR096")
+					(reference "#PWR96")
 					(unit 1)
 				)
 			)
@@ -73211,7 +83707,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 670.56 238.76 90)
+		(at 742.95 238.76 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -73219,8 +83715,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "555cc8fd-ab40-4a20-b336-137dfdc53a6b")
-		(property "Reference" "#PWR016"
-			(at 676.91 238.76 0)
+		(property "Reference" "#PWR16"
+			(at 749.3 238.76 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -73229,7 +83725,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 674.37 238.7599 90)
+			(at 746.76 238.7599 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -73238,7 +83734,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 670.56 238.76 0)
+			(at 742.95 238.76 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -73247,7 +83743,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 670.56 238.76 0)
+			(at 742.95 238.76 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -73256,7 +83752,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 670.56 238.76 0)
+			(at 742.95 238.76 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -73270,7 +83766,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR016")
+					(reference "#PWR16")
 					(unit 1)
 				)
 			)
@@ -73278,7 +83774,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 441.96 321.31 180)
+		(at 400.05 346.71 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -73286,8 +83782,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "5637e61f-fad7-46ed-b7e4-cf04418408fc")
-		(property "Reference" "#PWR0280"
-			(at 441.96 314.96 0)
+		(property "Reference" "#PWR280"
+			(at 400.05 340.36 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -73296,7 +83792,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 441.96 316.23 0)
+			(at 400.05 341.63 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -73305,7 +83801,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 441.96 321.31 0)
+			(at 400.05 346.71 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -73314,7 +83810,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 441.96 321.31 0)
+			(at 400.05 346.71 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -73323,7 +83819,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 441.96 321.31 0)
+			(at 400.05 346.71 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -73337,7 +83833,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0280")
+					(reference "#PWR280")
 					(unit 1)
 				)
 			)
@@ -73411,15 +83907,15 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 646.43 200.66 180)
+		(at 718.82 200.66 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
 		(uuid "56f74e95-5f9a-4440-a45d-856e8e407576")
-		(property "Reference" "#PWR0138"
-			(at 646.43 194.31 0)
+		(property "Reference" "#PWR138"
+			(at 718.82 194.31 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -73428,7 +83924,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 646.43 196.596 0)
+			(at 718.82 196.596 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -73436,7 +83932,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 646.43 200.66 0)
+			(at 718.82 200.66 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -73445,7 +83941,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 646.43 200.66 0)
+			(at 718.82 200.66 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -73454,7 +83950,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 646.43 200.66 0)
+			(at 718.82 200.66 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -73468,7 +83964,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0138")
+					(reference "#PWR138")
 					(unit 1)
 				)
 			)
@@ -73476,7 +83972,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 628.65 415.29 90)
+		(at 748.03 403.86 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -73484,7 +83980,7 @@
 		(dnp no)
 		(uuid "5782b49a-aff7-4a17-97ae-9b83a195fa85")
 		(property "Reference" "R21"
-			(at 630.174 417.322 90)
+			(at 749.554 405.892 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -73492,7 +83988,7 @@
 			)
 		)
 		(property "Value" "1k"
-			(at 626.364 417.322 90)
+			(at 745.744 405.892 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -73500,7 +83996,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 628.904 414.274 90)
+			(at 748.284 402.844 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -73509,7 +84005,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 628.65 415.29 0)
+			(at 748.03 403.86 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -73518,7 +84014,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 628.65 415.29 0)
+			(at 748.03 403.86 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -73551,7 +84047,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "5786bb47-05b1-4487-a07b-523e34c8b79b")
-		(property "Reference" "#PWR0345"
+		(property "Reference" "#PWR345"
 			(at 297.18 234.95 0)
 			(effects
 				(font
@@ -73602,7 +84098,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0345")
+					(reference "#PWR345")
 					(unit 1)
 				)
 			)
@@ -73921,7 +84417,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 651.51 322.58 270)
+		(at 581.66 377.19 270)
 		(mirror x)
 		(unit 1)
 		(exclude_from_sim no)
@@ -73930,8 +84426,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "5978fff2-994d-418e-a016-762dc821886b")
-		(property "Reference" "#PWR0134"
-			(at 645.16 322.58 0)
+		(property "Reference" "#PWR134"
+			(at 575.31 377.19 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -73940,7 +84436,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 647.7 322.5799 90)
+			(at 577.85 377.1899 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -73950,7 +84446,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 651.51 322.58 0)
+			(at 581.66 377.19 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -73959,7 +84455,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 651.51 322.58 0)
+			(at 581.66 377.19 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -73968,7 +84464,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 651.51 322.58 0)
+			(at 581.66 377.19 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -73982,7 +84478,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0134")
+					(reference "#PWR134")
 					(unit 1)
 				)
 			)
@@ -73990,15 +84486,15 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 637.54 170.18 0)
+		(at 709.93 170.18 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
 		(uuid "59a0b5e3-4db2-4109-b3f1-87fd9849c289")
-		(property "Reference" "#PWR0143"
-			(at 637.54 176.53 0)
+		(property "Reference" "#PWR143"
+			(at 709.93 176.53 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -74007,7 +84503,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 637.54 174.244 0)
+			(at 709.93 174.244 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -74015,7 +84511,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 637.54 170.18 0)
+			(at 709.93 170.18 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -74024,7 +84520,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 637.54 170.18 0)
+			(at 709.93 170.18 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -74033,7 +84529,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 637.54 170.18 0)
+			(at 709.93 170.18 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -74047,7 +84543,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0143")
+					(reference "#PWR143")
 					(unit 1)
 				)
 			)
@@ -74405,7 +84901,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "5d7be866-6e90-42bd-a84f-17aa23d0bd47")
-		(property "Reference" "#PWR0303"
+		(property "Reference" "#PWR303"
 			(at 435.61 182.88 0)
 			(effects
 				(font
@@ -74456,7 +84952,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0303")
+					(reference "#PWR303")
 					(unit 1)
 				)
 			)
@@ -74464,7 +84960,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 598.17 254 0)
+		(at 670.56 254 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -74472,8 +84968,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "5dc995af-8637-472a-bdb4-681f204590a5")
-		(property "Reference" "#PWR0141"
-			(at 598.17 260.35 0)
+		(property "Reference" "#PWR141"
+			(at 670.56 260.35 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -74482,7 +84978,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 598.17 259.08 0)
+			(at 670.56 259.08 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -74490,7 +84986,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 598.17 254 0)
+			(at 670.56 254 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -74499,7 +84995,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 598.17 254 0)
+			(at 670.56 254 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -74508,7 +85004,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 598.17 254 0)
+			(at 670.56 254 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -74522,7 +85018,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0141")
+					(reference "#PWR141")
 					(unit 1)
 				)
 			)
@@ -74538,7 +85034,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "5e8fdca2-e5ca-4fba-952a-7c706127611a")
-		(property "Reference" "#PWR071"
+		(property "Reference" "#PWR71"
 			(at 831.85 631.19 0)
 			(effects
 				(font
@@ -74588,7 +85084,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR071")
+					(reference "#PWR71")
 					(unit 1)
 				)
 			)
@@ -74665,7 +85161,7 @@
 	)
 	(symbol
 		(lib_id "power:+3.3V")
-		(at 593.09 246.38 90)
+		(at 665.48 246.38 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -74674,7 +85170,7 @@
 		(fields_autoplaced yes)
 		(uuid "5fdd66b1-4c52-43a1-8ce3-482545607a33")
 		(property "Reference" "#PWR017"
-			(at 596.9 246.38 0)
+			(at 669.29 246.38 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -74683,7 +85179,7 @@
 			)
 		)
 		(property "Value" "+3.3V"
-			(at 589.28 246.3799 90)
+			(at 661.67 246.3799 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -74692,7 +85188,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 593.09 246.38 0)
+			(at 665.48 246.38 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -74701,7 +85197,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 593.09 246.38 0)
+			(at 665.48 246.38 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -74710,7 +85206,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"+3.3V\""
-			(at 593.09 246.38 0)
+			(at 665.48 246.38 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -74740,7 +85236,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "5ff14500-6b1a-4444-a0b5-e0681557fa39")
-		(property "Reference" "#PWR019"
+		(property "Reference" "#PWR19"
 			(at 909.32 138.43 0)
 			(effects
 				(font
@@ -74791,7 +85287,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR019")
+					(reference "#PWR19")
 					(unit 1)
 				)
 			)
@@ -74943,7 +85439,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "6032dacd-4539-4418-815d-47e53592289f")
-		(property "Reference" "#PWR0184"
+		(property "Reference" "#PWR184"
 			(at 57.15 175.26 0)
 			(effects
 				(font
@@ -74993,7 +85489,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0184")
+					(reference "#PWR184")
 					(unit 1)
 				)
 			)
@@ -75070,7 +85566,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 911.86 339.09 0)
+		(at 843.28 389.89 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -75078,8 +85574,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "605a7b7b-3ef5-4485-afc0-639e76d896f2")
-		(property "Reference" "#PWR0107"
-			(at 911.86 345.44 0)
+		(property "Reference" "#PWR107"
+			(at 843.28 396.24 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -75088,7 +85584,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 911.86 344.17 0)
+			(at 843.28 394.97 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -75097,7 +85593,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 911.86 339.09 0)
+			(at 843.28 389.89 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -75106,7 +85602,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 911.86 339.09 0)
+			(at 843.28 389.89 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -75115,7 +85611,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 911.86 339.09 0)
+			(at 843.28 389.89 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -75129,7 +85625,7 @@
 		(instances
 			(project ""
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0107")
+					(reference "#PWR107")
 					(unit 1)
 				)
 			)
@@ -75274,7 +85770,7 @@
 	)
 	(symbol
 		(lib_id "power:+3.3V")
-		(at 633.73 288.29 180)
+		(at 706.12 288.29 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -75283,7 +85779,7 @@
 		(fields_autoplaced yes)
 		(uuid "6150d521-15a0-4e08-86d8-ac6fbcd52c8e")
 		(property "Reference" "#PWR0239"
-			(at 633.73 284.48 0)
+			(at 706.12 284.48 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -75292,7 +85788,7 @@
 			)
 		)
 		(property "Value" "+3.3V"
-			(at 633.73 293.37 0)
+			(at 706.12 293.37 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -75300,7 +85796,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 633.73 288.29 0)
+			(at 706.12 288.29 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -75309,7 +85805,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 633.73 288.29 0)
+			(at 706.12 288.29 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -75318,7 +85814,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"+3.3V\""
-			(at 633.73 288.29 0)
+			(at 706.12 288.29 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -75348,7 +85844,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "622c1431-77f4-4e14-9eaa-c00c5e869a4d")
-		(property "Reference" "#PWR0199"
+		(property "Reference" "#PWR199"
 			(at 166.37 713.74 0)
 			(effects
 				(font
@@ -75398,7 +85894,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0199")
+					(reference "#PWR199")
 					(unit 1)
 				)
 			)
@@ -75406,7 +85902,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 834.39 355.6 0)
+		(at 731.52 355.6 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -75414,8 +85910,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "6236b9f9-9e5e-41fa-91ff-f8f06c089c09")
-		(property "Reference" "#PWR0320"
-			(at 834.39 361.95 0)
+		(property "Reference" "#PWR320"
+			(at 731.52 361.95 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -75424,7 +85920,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 834.39 360.68 0)
+			(at 731.52 360.68 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -75433,7 +85929,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 834.39 355.6 0)
+			(at 731.52 355.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -75442,7 +85938,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 834.39 355.6 0)
+			(at 731.52 355.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -75451,7 +85947,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 834.39 355.6 0)
+			(at 731.52 355.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -75465,7 +85961,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0320")
+					(reference "#PWR320")
 					(unit 1)
 				)
 			)
@@ -75540,7 +86036,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 636.27 350.52 0)
+		(at 566.42 405.13 0)
 		(mirror y)
 		(unit 1)
 		(exclude_from_sim no)
@@ -75549,8 +86045,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "6374bde9-dbf5-4a21-a09d-28176eb561c7")
-		(property "Reference" "#PWR0112"
-			(at 636.27 356.87 0)
+		(property "Reference" "#PWR112"
+			(at 566.42 411.48 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -75559,7 +86055,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 636.2699 354.33 90)
+			(at 566.4199 408.94 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -75569,7 +86065,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 636.27 350.52 0)
+			(at 566.42 405.13 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -75578,7 +86074,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 636.27 350.52 0)
+			(at 566.42 405.13 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -75587,7 +86083,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 636.27 350.52 0)
+			(at 566.42 405.13 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -75601,7 +86097,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0112")
+					(reference "#PWR112")
 					(unit 1)
 				)
 			)
@@ -75746,7 +86242,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 651.51 332.74 270)
+		(at 581.66 387.35 270)
 		(mirror x)
 		(unit 1)
 		(exclude_from_sim no)
@@ -75755,8 +86251,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "64d5f55e-eb65-4915-b89d-971d8da9d778")
-		(property "Reference" "#PWR0136"
-			(at 645.16 332.74 0)
+		(property "Reference" "#PWR136"
+			(at 575.31 387.35 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -75765,7 +86261,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 647.7 332.7399 90)
+			(at 577.85 387.3499 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -75775,7 +86271,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 651.51 332.74 0)
+			(at 581.66 387.35 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -75784,7 +86280,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 651.51 332.74 0)
+			(at 581.66 387.35 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -75793,7 +86289,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 651.51 332.74 0)
+			(at 581.66 387.35 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -75807,7 +86303,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0136")
+					(reference "#PWR136")
 					(unit 1)
 				)
 			)
@@ -75815,7 +86311,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 436.88 340.36 0)
+		(at 394.97 365.76 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -75823,7 +86319,7 @@
 		(dnp no)
 		(uuid "64dead2b-46e0-4479-8d5a-95eeb53dc616")
 		(property "Reference" "C129"
-			(at 428.752 339.09 0)
+			(at 386.842 364.49 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -75832,7 +86328,7 @@
 			)
 		)
 		(property "Value" "0.1uF"
-			(at 428.752 341.63 0)
+			(at 386.842 367.03 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -75841,7 +86337,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 437.8452 344.17 0)
+			(at 395.9352 369.57 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -75850,7 +86346,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 436.88 340.36 0)
+			(at 394.97 365.76 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -75859,7 +86355,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 436.88 340.36 0)
+			(at 394.97 365.76 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -75884,7 +86380,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 576.58 322.58 180)
+		(at 529.59 379.73 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -75892,7 +86388,7 @@
 		(dnp no)
 		(uuid "64e642b6-6fed-4265-a82c-4c5cca36af26")
 		(property "Reference" "C39"
-			(at 573.278 323.596 0)
+			(at 526.288 380.746 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -75901,7 +86397,7 @@
 			)
 		)
 		(property "Value" "270pF"
-			(at 574.04 321.564 0)
+			(at 527.05 378.714 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -75910,7 +86406,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 575.6148 318.77 0)
+			(at 528.6248 375.92 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -75919,7 +86415,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 576.58 322.58 0)
+			(at 529.59 379.73 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -75928,7 +86424,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 576.58 322.58 0)
+			(at 529.59 379.73 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -75953,7 +86449,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 646.43 327.66 270)
+		(at 576.58 382.27 270)
 		(mirror x)
 		(unit 1)
 		(exclude_from_sim no)
@@ -75962,7 +86458,7 @@
 		(dnp no)
 		(uuid "65416871-f69c-48bd-89ae-32d3fa097251")
 		(property "Reference" "R13"
-			(at 646.43 331.47 90)
+			(at 576.58 386.08 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -75970,7 +86466,7 @@
 			)
 		)
 		(property "Value" "1k"
-			(at 646.43 329.692 90)
+			(at 576.58 384.302 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -75978,7 +86474,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 646.176 326.644 90)
+			(at 576.326 381.254 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -75987,7 +86483,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 646.43 327.66 0)
+			(at 576.58 382.27 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -75996,7 +86492,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 646.43 327.66 0)
+			(at 576.58 382.27 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -76091,7 +86587,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 520.7 233.68 90)
+		(at 618.49 267.97 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -76100,7 +86596,7 @@
 		(fields_autoplaced yes)
 		(uuid "65940ec2-fa04-4f70-b727-c2a2d6fa9b36")
 		(property "Reference" "C84"
-			(at 520.7 226.06 90)
+			(at 618.49 260.35 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -76108,7 +86604,7 @@
 			)
 		)
 		(property "Value" "1nF"
-			(at 520.7 228.6 90)
+			(at 618.49 262.89 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -76116,7 +86612,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 524.51 232.7148 0)
+			(at 622.3 267.0048 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -76125,7 +86621,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 520.7 233.68 0)
+			(at 618.49 267.97 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -76134,7 +86630,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 520.7 233.68 0)
+			(at 618.49 267.97 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -76167,7 +86663,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "65997250-b796-4150-a5f1-9ede898fa5ae")
-		(property "Reference" "#PWR093"
+		(property "Reference" "#PWR93"
 			(at 297.18 186.69 0)
 			(effects
 				(font
@@ -76218,7 +86714,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR093")
+					(reference "#PWR93")
 					(unit 1)
 				)
 			)
@@ -76234,7 +86730,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "65ecb4db-ae63-4b73-91ff-bf40da7cf70b")
-		(property "Reference" "#PWR0209"
+		(property "Reference" "#PWR209"
 			(at 113.03 740.41 0)
 			(effects
 				(font
@@ -76284,7 +86780,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0209")
+					(reference "#PWR209")
 					(unit 1)
 				)
 			)
@@ -76437,7 +86933,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "66dffe5c-3928-4e22-9af2-e61dd7279383")
-		(property "Reference" "#PWR0298"
+		(property "Reference" "#PWR298"
 			(at 401.32 77.47 0)
 			(effects
 				(font
@@ -76488,7 +86984,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0298")
+					(reference "#PWR298")
 					(unit 1)
 				)
 			)
@@ -76496,7 +86992,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 834.39 334.01 0)
+		(at 731.52 334.01 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -76504,7 +87000,7 @@
 		(dnp no)
 		(uuid "67055361-f6b8-4d2d-8f16-5770723a4b9d")
 		(property "Reference" "C148"
-			(at 828.802 331.978 0)
+			(at 725.932 331.978 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -76513,7 +87009,7 @@
 			)
 		)
 		(property "Value" "3.3pF"
-			(at 834.898 331.978 0)
+			(at 732.028 331.978 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -76522,7 +87018,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 835.3552 337.82 0)
+			(at 732.4852 337.82 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -76531,7 +87027,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 834.39 334.01 0)
+			(at 731.52 334.01 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -76540,7 +87036,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 834.39 334.01 0)
+			(at 731.52 334.01 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -76636,7 +87132,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 626.11 392.43 90)
+		(at 745.49 381 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -76644,8 +87140,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "67cbadee-a7ef-4a09-a743-a951c84dcb1a")
-		(property "Reference" "#PWR0130"
-			(at 632.46 392.43 0)
+		(property "Reference" "#PWR130"
+			(at 751.84 381 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -76654,7 +87150,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 629.92 392.4299 90)
+			(at 749.3 380.9999 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -76664,7 +87160,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 626.11 392.43 0)
+			(at 745.49 381 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -76673,7 +87169,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 626.11 392.43 0)
+			(at 745.49 381 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -76682,7 +87178,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 626.11 392.43 0)
+			(at 745.49 381 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -76696,7 +87192,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0130")
+					(reference "#PWR130")
 					(unit 1)
 				)
 			)
@@ -76712,7 +87208,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "6800076b-4270-4e33-b4cf-fccf3d6ae327")
-		(property "Reference" "#PWR0275"
+		(property "Reference" "#PWR275"
 			(at 633.73 129.54 0)
 			(effects
 				(font
@@ -76763,7 +87259,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0275")
+					(reference "#PWR275")
 					(unit 1)
 				)
 			)
@@ -76976,7 +87472,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 834.39 351.79 0)
+		(at 731.52 351.79 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -76984,7 +87480,7 @@
 		(dnp no)
 		(uuid "68f42ba1-36e6-4522-be99-74893043d8a0")
 		(property "Reference" "C149"
-			(at 828.802 349.758 0)
+			(at 725.932 349.758 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -76993,7 +87489,7 @@
 			)
 		)
 		(property "Value" "3.3pF"
-			(at 834.644 349.758 0)
+			(at 731.774 349.758 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -77002,7 +87498,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 835.3552 355.6 0)
+			(at 732.4852 355.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -77011,7 +87507,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 834.39 351.79 0)
+			(at 731.52 351.79 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -77020,7 +87516,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 834.39 351.79 0)
+			(at 731.52 351.79 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -77045,7 +87541,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 680.72 261.62 0)
+		(at 753.11 261.62 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -77053,7 +87549,7 @@
 		(dnp no)
 		(uuid "6918df1a-94e7-481c-8ea9-5faa0709ebaf")
 		(property "Reference" "C87"
-			(at 683.26 260.35 0)
+			(at 755.65 260.35 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -77062,7 +87558,7 @@
 			)
 		)
 		(property "Value" "0.1uF"
-			(at 683.26 262.89 0)
+			(at 755.65 262.89 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -77071,7 +87567,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 681.6852 265.43 0)
+			(at 754.0752 265.43 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -77080,7 +87576,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 680.72 261.62 0)
+			(at 753.11 261.62 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -77089,7 +87585,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 680.72 261.62 0)
+			(at 753.11 261.62 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -77114,7 +87610,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 1155.7 342.9 0)
+		(at 1087.12 393.7 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -77122,8 +87618,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "69436393-d3ed-44c5-93b5-37eec5651c02")
-		(property "Reference" "#PWR025"
-			(at 1155.7 349.25 0)
+		(property "Reference" "#PWR25"
+			(at 1087.12 400.05 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -77132,7 +87628,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 1155.7 347.98 0)
+			(at 1087.12 398.78 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -77140,7 +87636,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 1155.7 342.9 0)
+			(at 1087.12 393.7 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -77149,7 +87645,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 1155.7 342.9 0)
+			(at 1087.12 393.7 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -77158,7 +87654,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 1155.7 342.9 0)
+			(at 1087.12 393.7 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -77172,7 +87668,7 @@
 		(instances
 			(project ""
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR025")
+					(reference "#PWR25")
 					(unit 1)
 				)
 			)
@@ -77188,7 +87684,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "697a7b83-c130-4ab4-adf5-579f9e8f573b")
-		(property "Reference" "#PWR095"
+		(property "Reference" "#PWR95"
 			(at 297.18 245.11 0)
 			(effects
 				(font
@@ -77239,7 +87735,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR095")
+					(reference "#PWR95")
 					(unit 1)
 				)
 			)
@@ -77247,7 +87743,7 @@
 	)
 	(symbol
 		(lib_id "Device:L")
-		(at 570.23 341.63 270)
+		(at 523.24 398.78 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -77255,7 +87751,7 @@
 		(dnp no)
 		(uuid "6a7711b5-98cb-4932-996b-42330281f5e0")
 		(property "Reference" "L9"
-			(at 570.23 337.566 90)
+			(at 523.24 394.716 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -77264,7 +87760,7 @@
 			)
 		)
 		(property "Value" "27uH"
-			(at 570.23 339.852 90)
+			(at 523.24 397.002 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -77272,7 +87768,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 570.23 341.63 0)
+			(at 523.24 398.78 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -77281,7 +87777,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 570.23 341.63 0)
+			(at 523.24 398.78 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -77290,7 +87786,7 @@
 			)
 		)
 		(property "Description" "Inductor"
-			(at 570.23 341.63 0)
+			(at 523.24 398.78 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -77515,7 +88011,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 1021.08 344.17 90)
+		(at 952.5 394.97 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -77523,8 +88019,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "6bfe4ce8-d784-4645-9868-d4bf2b521ff2")
-		(property "Reference" "#PWR031"
-			(at 1027.43 344.17 0)
+		(property "Reference" "#PWR31"
+			(at 958.85 394.97 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -77533,7 +88029,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 1024.89 344.1699 90)
+			(at 956.31 394.9699 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -77542,7 +88038,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 1021.08 344.17 0)
+			(at 952.5 394.97 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -77551,7 +88047,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 1021.08 344.17 0)
+			(at 952.5 394.97 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -77560,7 +88056,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 1021.08 344.17 0)
+			(at 952.5 394.97 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -77574,7 +88070,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR031")
+					(reference "#PWR31")
 					(unit 1)
 				)
 			)
@@ -77590,7 +88086,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "6c26d9b6-a419-41a9-a659-16565581dd95")
-		(property "Reference" "#PWR0233"
+		(property "Reference" "#PWR233"
 			(at 243.84 617.22 0)
 			(effects
 				(font
@@ -77641,7 +88137,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0233")
+					(reference "#PWR233")
 					(unit 1)
 				)
 			)
@@ -77793,7 +88289,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "6db61ed4-7d55-4f00-b19b-1f1d3f4404b3")
-		(property "Reference" "#PWR02"
+		(property "Reference" "#PWR2"
 			(at 669.29 49.53 0)
 			(effects
 				(font
@@ -77844,7 +88340,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR02")
+					(reference "#PWR2")
 					(unit 1)
 				)
 			)
@@ -77852,7 +88348,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 563.88 347.98 180)
+		(at 516.89 405.13 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -77860,7 +88356,7 @@
 		(dnp no)
 		(uuid "6db8fb1f-8fc2-4e35-8b72-181bf38006bf")
 		(property "Reference" "C40"
-			(at 560.832 348.996 0)
+			(at 513.842 406.146 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -77869,7 +88365,7 @@
 			)
 		)
 		(property "Value" "91pF"
-			(at 561.086 346.964 0)
+			(at 514.096 404.114 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -77878,7 +88374,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 562.9148 344.17 0)
+			(at 515.9248 401.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -77887,7 +88383,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 563.88 347.98 0)
+			(at 516.89 405.13 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -77896,7 +88392,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 563.88 347.98 0)
+			(at 516.89 405.13 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -77921,7 +88417,7 @@
 	)
 	(symbol
 		(lib_id "power:+3.3V")
-		(at 633.73 193.04 0)
+		(at 706.12 193.04 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -77930,7 +88426,7 @@
 		(fields_autoplaced yes)
 		(uuid "6de9144e-a06b-45a8-a8c9-e87dd984d917")
 		(property "Reference" "#PWR0117"
-			(at 633.73 196.85 0)
+			(at 706.12 196.85 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -77939,7 +88435,7 @@
 			)
 		)
 		(property "Value" "+3.3V"
-			(at 633.73 187.96 0)
+			(at 706.12 187.96 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -77947,7 +88443,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 633.73 193.04 0)
+			(at 706.12 193.04 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -77956,7 +88452,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 633.73 193.04 0)
+			(at 706.12 193.04 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -77965,7 +88461,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"+3.3V\""
-			(at 633.73 193.04 0)
+			(at 706.12 193.04 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -78066,7 +88562,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "702b1c4b-c7fa-4e48-bd1a-e06c43b5a192")
-		(property "Reference" "#PWR0257"
+		(property "Reference" "#PWR257"
 			(at 135.89 252.73 0)
 			(effects
 				(font
@@ -78116,7 +88612,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0257")
+					(reference "#PWR257")
 					(unit 1)
 				)
 			)
@@ -78220,7 +88716,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "70d6acd4-abbb-4897-92d6-b558c19ac680")
-		(property "Reference" "#PWR038"
+		(property "Reference" "#PWR38"
 			(at 222.25 396.24 0)
 			(effects
 				(font
@@ -78271,7 +88767,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR038")
+					(reference "#PWR38")
 					(unit 1)
 				)
 			)
@@ -78279,15 +88775,15 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 631.19 200.66 180)
+		(at 703.58 200.66 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
 		(uuid "70efcb65-d229-40c5-84ba-96d0105ea25b")
-		(property "Reference" "#PWR0235"
-			(at 631.19 194.31 0)
+		(property "Reference" "#PWR235"
+			(at 703.58 194.31 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -78296,7 +88792,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 631.19 196.85 0)
+			(at 703.58 196.85 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -78304,7 +88800,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 631.19 200.66 0)
+			(at 703.58 200.66 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -78313,7 +88809,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 631.19 200.66 0)
+			(at 703.58 200.66 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -78322,7 +88818,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 631.19 200.66 0)
+			(at 703.58 200.66 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -78336,7 +88832,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0235")
+					(reference "#PWR235")
 					(unit 1)
 				)
 			)
@@ -78352,7 +88848,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "7144cbe1-dc4d-4b09-a898-d0d0f9514a50")
-		(property "Reference" "#PWR0104"
+		(property "Reference" "#PWR104"
 			(at 308.61 158.75 0)
 			(effects
 				(font
@@ -78403,7 +88899,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0104")
+					(reference "#PWR104")
 					(unit 1)
 				)
 			)
@@ -78621,7 +89117,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 654.05 410.21 0)
+		(at 773.43 398.78 0)
 		(mirror y)
 		(unit 1)
 		(exclude_from_sim no)
@@ -78630,7 +89126,7 @@
 		(dnp no)
 		(uuid "71bba64a-3863-479e-bafa-12b0a6de2e55")
 		(property "Reference" "C51"
-			(at 650.494 408.432 0)
+			(at 769.874 397.002 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -78639,7 +89135,7 @@
 			)
 		)
 		(property "Value" "100pF"
-			(at 651.51 410.21 0)
+			(at 770.89 398.78 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -78648,7 +89144,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 653.0848 414.02 0)
+			(at 772.4648 402.59 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -78657,7 +89153,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 654.05 410.21 0)
+			(at 773.43 398.78 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -78666,7 +89162,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 654.05 410.21 0)
+			(at 773.43 398.78 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -78691,7 +89187,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 916.94 359.41 90)
+		(at 848.36 410.21 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -78699,7 +89195,7 @@
 		(dnp no)
 		(uuid "71f0a323-883f-4872-9eb1-c14d2ed6cdd0")
 		(property "Reference" "C53"
-			(at 914.908 355.854 90)
+			(at 846.328 406.654 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -78708,7 +89204,7 @@
 			)
 		)
 		(property "Value" "1000pF"
-			(at 913.638 362.966 90)
+			(at 845.058 413.766 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -78717,7 +89213,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 920.75 358.4448 0)
+			(at 852.17 409.2448 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -78726,7 +89222,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 916.94 359.41 0)
+			(at 848.36 410.21 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -78735,7 +89231,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 916.94 359.41 0)
+			(at 848.36 410.21 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -78760,7 +89256,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 631.19 421.64 90)
+		(at 750.57 410.21 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -78768,7 +89264,7 @@
 		(dnp no)
 		(uuid "725b4825-9214-4a19-9d45-53c7a7bcd19c")
 		(property "Reference" "R22"
-			(at 632.714 419.862 90)
+			(at 752.094 408.432 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -78776,7 +89272,7 @@
 			)
 		)
 		(property "Value" "1k"
-			(at 628.904 419.862 90)
+			(at 748.284 408.432 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -78784,7 +89280,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 631.444 420.624 90)
+			(at 750.824 409.194 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -78793,7 +89289,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 631.19 421.64 0)
+			(at 750.57 410.21 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -78802,7 +89298,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 631.19 421.64 0)
+			(at 750.57 410.21 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -78962,6 +89458,7 @@
 		)
 	)
 	(symbol
+		(lib_name "DSC1001CI2-100.0000T_1")
 		(lib_id "LIB_IRISHSAT:DSC1001CI2-100.0000T")
 		(at 58.42 166.37 0)
 		(unit 1)
@@ -79185,7 +89682,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "741fa5ef-a837-4bca-97a7-4600ee2feb61")
-		(property "Reference" "#PWR070"
+		(property "Reference" "#PWR70"
 			(at 68.58 659.13 0)
 			(effects
 				(font
@@ -79235,7 +89732,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR070")
+					(reference "#PWR70")
 					(unit 1)
 				)
 			)
@@ -79243,7 +89740,7 @@
 	)
 	(symbol
 		(lib_id "power:+5V")
-		(at 1080.77 313.69 0)
+		(at 1012.19 364.49 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -79252,7 +89749,7 @@
 		(fields_autoplaced yes)
 		(uuid "747d0781-66d5-4ee1-aaa6-c542dfb971ce")
 		(property "Reference" "#PWR0161"
-			(at 1080.77 317.5 0)
+			(at 1012.19 368.3 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -79261,7 +89758,7 @@
 			)
 		)
 		(property "Value" "+5V"
-			(at 1080.77 308.61 0)
+			(at 1012.19 359.41 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -79269,7 +89766,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 1080.77 313.69 0)
+			(at 1012.19 364.49 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -79278,7 +89775,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 1080.77 313.69 0)
+			(at 1012.19 364.49 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -79287,7 +89784,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"+5V\""
-			(at 1080.77 313.69 0)
+			(at 1012.19 364.49 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -79317,7 +89814,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "7496afdd-5893-4fb6-b198-0bcd05da026b")
-		(property "Reference" "#PWR042"
+		(property "Reference" "#PWR42"
 			(at 222.25 240.03 0)
 			(effects
 				(font
@@ -79368,7 +89865,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR042")
+					(reference "#PWR42")
 					(unit 1)
 				)
 			)
@@ -79376,15 +89873,15 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 636.27 200.66 180)
+		(at 708.66 200.66 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
 		(uuid "7518a366-6b68-40e8-8097-77e2539f281a")
-		(property "Reference" "#PWR0139"
-			(at 636.27 194.31 0)
+		(property "Reference" "#PWR139"
+			(at 708.66 194.31 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -79393,7 +89890,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 636.27 196.85 0)
+			(at 708.66 196.85 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -79401,7 +89898,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 636.27 200.66 0)
+			(at 708.66 200.66 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -79410,7 +89907,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 636.27 200.66 0)
+			(at 708.66 200.66 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -79419,7 +89916,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 636.27 200.66 0)
+			(at 708.66 200.66 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -79433,7 +89930,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0139")
+					(reference "#PWR139")
 					(unit 1)
 				)
 			)
@@ -79508,7 +90005,7 @@
 	)
 	(symbol
 		(lib_id "power:+5V")
-		(at 712.47 327.66 270)
+		(at 642.62 382.27 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -79517,7 +90014,7 @@
 		(fields_autoplaced yes)
 		(uuid "768e98cf-fc8e-4053-af2e-607b7476dc0c")
 		(property "Reference" "#PWR0267"
-			(at 708.66 327.66 0)
+			(at 638.81 382.27 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -79526,7 +90023,7 @@
 			)
 		)
 		(property "Value" "+5V"
-			(at 716.28 327.6599 90)
+			(at 646.43 382.2699 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -79535,7 +90032,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 712.47 327.66 0)
+			(at 642.62 382.27 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -79544,7 +90041,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 712.47 327.66 0)
+			(at 642.62 382.27 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -79553,7 +90050,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"+5V\""
-			(at 712.47 327.66 0)
+			(at 642.62 382.27 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -79575,7 +90072,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 427.99 369.57 90)
+		(at 386.08 394.97 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -79583,7 +90080,7 @@
 		(dnp no)
 		(uuid "77468728-2db9-4b2c-8daf-702b736d8465")
 		(property "Reference" "C52"
-			(at 429.514 371.094 90)
+			(at 387.604 396.494 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -79592,7 +90089,7 @@
 			)
 		)
 		(property "Value" ".1uF"
-			(at 422.402 371.094 90)
+			(at 380.492 396.494 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -79601,7 +90098,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 431.8 368.6048 0)
+			(at 389.89 394.0048 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -79610,7 +90107,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 427.99 369.57 0)
+			(at 386.08 394.97 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -79619,7 +90116,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 427.99 369.57 0)
+			(at 386.08 394.97 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -79848,7 +90345,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 436.88 383.54 270)
+		(at 394.97 408.94 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -79856,8 +90353,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "786a7ec7-b05c-42df-8777-d4bf0bc70e1b")
-		(property "Reference" "#PWR046"
-			(at 430.53 383.54 0)
+		(property "Reference" "#PWR46"
+			(at 388.62 408.94 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -79866,7 +90363,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 433.07 383.5399 90)
+			(at 391.16 408.9399 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -79876,7 +90373,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 436.88 383.54 0)
+			(at 394.97 408.94 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -79885,7 +90382,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 436.88 383.54 0)
+			(at 394.97 408.94 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -79894,7 +90391,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 436.88 383.54 0)
+			(at 394.97 408.94 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -79908,7 +90405,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR046")
+					(reference "#PWR46")
 					(unit 1)
 				)
 			)
@@ -79916,7 +90413,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 676.91 217.17 0)
+		(at 749.3 217.17 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -79924,7 +90421,7 @@
 		(dnp no)
 		(uuid "7a390082-bcf3-4149-8b1e-dd7c1fabdd02")
 		(property "Reference" "C89"
-			(at 680.72 215.8999 0)
+			(at 753.11 215.8999 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -79933,7 +90430,7 @@
 			)
 		)
 		(property "Value" "0.1uF"
-			(at 680.72 218.4399 0)
+			(at 753.11 218.4399 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -79942,7 +90439,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 677.8752 220.98 0)
+			(at 750.2652 220.98 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -79951,7 +90448,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 676.91 217.17 0)
+			(at 749.3 217.17 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -79960,7 +90457,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 676.91 217.17 0)
+			(at 749.3 217.17 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -79985,7 +90482,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 593.09 354.33 270)
+		(at 546.1 411.48 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -79993,7 +90490,7 @@
 		(dnp no)
 		(uuid "7a58c104-8a73-4fd3-84ab-f0443bd78761")
 		(property "Reference" "C31"
-			(at 593.09 359.918 90)
+			(at 546.1 417.068 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -80001,7 +90498,7 @@
 			)
 		)
 		(property "Value" "10uF"
-			(at 593.09 357.886 90)
+			(at 546.1 415.036 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -80009,7 +90506,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 589.28 355.2952 0)
+			(at 542.29 412.4452 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -80018,7 +90515,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 593.09 354.33 0)
+			(at 546.1 411.48 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -80027,7 +90524,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 593.09 354.33 0)
+			(at 546.1 411.48 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -80060,7 +90557,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "7ae3a3b5-0e83-493c-9255-44879b8dfc6d")
-		(property "Reference" "#PWR0151"
+		(property "Reference" "#PWR151"
 			(at 605.79 106.68 0)
 			(effects
 				(font
@@ -80111,7 +90608,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0151")
+					(reference "#PWR151")
 					(unit 1)
 				)
 			)
@@ -80127,7 +90624,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "7b4fa06c-4d4e-4c41-b7fb-0b8bf2843438")
-		(property "Reference" "#PWR0305"
+		(property "Reference" "#PWR305"
 			(at 440.69 96.52 0)
 			(effects
 				(font
@@ -80178,7 +90675,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0305")
+					(reference "#PWR305")
 					(unit 1)
 				)
 			)
@@ -80186,7 +90683,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 480.06 365.76 90)
+		(at 438.15 391.16 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -80194,8 +90691,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "7b8a2a97-0759-42d8-9771-15c941a5fd7b")
-		(property "Reference" "#PWR050"
-			(at 486.41 365.76 0)
+		(property "Reference" "#PWR50"
+			(at 444.5 391.16 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -80204,7 +90701,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 483.87 365.7599 90)
+			(at 441.96 391.1599 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -80214,7 +90711,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 480.06 365.76 0)
+			(at 438.15 391.16 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -80223,7 +90720,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 480.06 365.76 0)
+			(at 438.15 391.16 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -80232,7 +90729,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 480.06 365.76 0)
+			(at 438.15 391.16 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -80246,7 +90743,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR050")
+					(reference "#PWR50")
 					(unit 1)
 				)
 			)
@@ -80254,7 +90751,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 626.11 402.59 90)
+		(at 745.49 391.16 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -80262,8 +90759,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "7bce8cf1-fe58-4c49-a287-df535655d838")
-		(property "Reference" "#PWR0131"
-			(at 632.46 402.59 0)
+		(property "Reference" "#PWR131"
+			(at 751.84 391.16 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -80272,7 +90769,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 629.92 402.5899 90)
+			(at 749.3 391.1599 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -80282,7 +90779,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 626.11 402.59 0)
+			(at 745.49 391.16 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -80291,7 +90788,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 626.11 402.59 0)
+			(at 745.49 391.16 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -80300,7 +90797,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 626.11 402.59 0)
+			(at 745.49 391.16 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -80314,7 +90811,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0131")
+					(reference "#PWR131")
 					(unit 1)
 				)
 			)
@@ -80330,7 +90827,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "7cb52da1-f4fd-4189-ad25-7ad3238a7a7d")
-		(property "Reference" "#PWR0325"
+		(property "Reference" "#PWR325"
 			(at 454.66 88.9 0)
 			(effects
 				(font
@@ -80381,7 +90878,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0325")
+					(reference "#PWR325")
 					(unit 1)
 				)
 			)
@@ -80464,7 +90961,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "7d3ee34c-3990-42e8-a015-7eb425e743d5")
-		(property "Reference" "#PWR056"
+		(property "Reference" "#PWR56"
 			(at 1005.84 692.15 0)
 			(effects
 				(font
@@ -80515,7 +91012,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR056")
+					(reference "#PWR56")
 					(unit 1)
 				)
 			)
@@ -80601,7 +91098,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "7d89f972-c8e7-4d1a-a87d-f684c45b699d")
-		(property "Reference" "#PWR03"
+		(property "Reference" "#PWR3"
 			(at 669.29 52.07 0)
 			(effects
 				(font
@@ -80652,7 +91149,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR03")
+					(reference "#PWR3")
 					(unit 1)
 				)
 			)
@@ -80796,7 +91293,7 @@
 	)
 	(symbol
 		(lib_id "power:+5V")
-		(at 711.2 342.9 270)
+		(at 641.35 397.51 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -80804,7 +91301,7 @@
 		(dnp no)
 		(uuid "7e125df0-ef4e-4390-81bd-5084dc8df81d")
 		(property "Reference" "#PWR0266"
-			(at 707.39 342.9 0)
+			(at 637.54 397.51 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -80813,7 +91310,7 @@
 			)
 		)
 		(property "Value" "+5V"
-			(at 715.01 342.8999 90)
+			(at 645.16 397.5099 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -80822,7 +91319,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 711.2 342.9 0)
+			(at 641.35 397.51 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -80831,7 +91328,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 711.2 342.9 0)
+			(at 641.35 397.51 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -80840,7 +91337,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"+5V\""
-			(at 711.2 342.9 0)
+			(at 641.35 397.51 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -80870,7 +91367,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "7e8c9a52-eaca-43f7-bc3b-ed6791c47167")
-		(property "Reference" "#PWR084"
+		(property "Reference" "#PWR84"
 			(at 165.1 674.37 0)
 			(effects
 				(font
@@ -80921,7 +91418,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR084")
+					(reference "#PWR84")
 					(unit 1)
 				)
 			)
@@ -80937,7 +91434,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "7e8d5752-1f38-48bf-a290-211fa6597df8")
-		(property "Reference" "#PWR07"
+		(property "Reference" "#PWR7"
 			(at 669.29 62.23 0)
 			(effects
 				(font
@@ -80988,7 +91485,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR07")
+					(reference "#PWR7")
 					(unit 1)
 				)
 			)
@@ -80996,7 +91493,7 @@
 	)
 	(symbol
 		(lib_id "Device:L")
-		(at 570.23 328.93 270)
+		(at 523.24 386.08 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -81004,7 +91501,7 @@
 		(dnp no)
 		(uuid "7e9e7360-d626-46fc-a69a-5bbd18217a95")
 		(property "Reference" "L10"
-			(at 570.23 327.406 90)
+			(at 523.24 384.556 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -81012,7 +91509,7 @@
 			)
 		)
 		(property "Value" "27uH"
-			(at 570.23 331.47 90)
+			(at 523.24 388.62 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -81020,7 +91517,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 570.23 328.93 0)
+			(at 523.24 386.08 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -81029,7 +91526,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 570.23 328.93 0)
+			(at 523.24 386.08 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -81038,7 +91535,7 @@
 			)
 		)
 		(property "Description" "Inductor"
-			(at 570.23 328.93 0)
+			(at 523.24 386.08 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -81209,7 +91706,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "810c0d0c-446c-4ef8-b26d-55ee53117e3d")
-		(property "Reference" "#PWR0145"
+		(property "Reference" "#PWR145"
 			(at 715.01 149.86 0)
 			(effects
 				(font
@@ -81260,7 +91757,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0145")
+					(reference "#PWR145")
 					(unit 1)
 				)
 			)
@@ -81402,7 +91899,7 @@
 	)
 	(symbol
 		(lib_id "Device:L")
-		(at 803.91 337.82 270)
+		(at 701.04 337.82 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -81411,7 +91908,7 @@
 		(fields_autoplaced yes)
 		(uuid "82139724-bfb8-45ef-b833-a2a01b38a6c3")
 		(property "Reference" "L29"
-			(at 803.91 332.74 90)
+			(at 701.04 332.74 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -81419,7 +91916,7 @@
 			)
 		)
 		(property "Value" "2.7nH"
-			(at 803.91 335.28 90)
+			(at 701.04 335.28 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -81427,7 +91924,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 803.91 337.82 0)
+			(at 701.04 337.82 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -81436,7 +91933,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 803.91 337.82 0)
+			(at 701.04 337.82 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -81445,7 +91942,7 @@
 			)
 		)
 		(property "Description" "Inductor"
-			(at 803.91 337.82 0)
+			(at 701.04 337.82 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -81845,7 +92342,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 434.34 411.48 0)
+		(at 392.43 436.88 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -81853,8 +92350,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "832eb09f-52b4-4df1-bda8-b01cbb2f6caa")
-		(property "Reference" "#PWR0295"
-			(at 434.34 417.83 0)
+		(property "Reference" "#PWR295"
+			(at 392.43 443.23 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -81863,7 +92360,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 434.34 416.56 0)
+			(at 392.43 441.96 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -81872,7 +92369,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 434.34 411.48 0)
+			(at 392.43 436.88 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -81881,7 +92378,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 434.34 411.48 0)
+			(at 392.43 436.88 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -81890,7 +92387,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 434.34 411.48 0)
+			(at 392.43 436.88 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -81904,7 +92401,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0295")
+					(reference "#PWR295")
 					(unit 1)
 				)
 			)
@@ -81912,7 +92409,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 911.86 351.79 180)
+		(at 843.28 402.59 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -81920,8 +92417,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "843e38ca-dad4-4d0e-94e0-8141c0a7d413")
-		(property "Reference" "#PWR0108"
-			(at 911.86 345.44 0)
+		(property "Reference" "#PWR108"
+			(at 843.28 396.24 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -81930,7 +92427,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 911.86 346.71 0)
+			(at 843.28 397.51 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -81939,7 +92436,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 911.86 351.79 0)
+			(at 843.28 402.59 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -81948,7 +92445,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 911.86 351.79 0)
+			(at 843.28 402.59 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -81957,7 +92454,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 911.86 351.79 0)
+			(at 843.28 402.59 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -81971,7 +92468,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0108")
+					(reference "#PWR108")
 					(unit 1)
 				)
 			)
@@ -81979,7 +92476,7 @@
 	)
 	(symbol
 		(lib_id "Device:L")
-		(at 911.86 355.6 0)
+		(at 843.28 406.4 0)
 		(mirror x)
 		(unit 1)
 		(exclude_from_sim no)
@@ -81988,7 +92485,7 @@
 		(dnp no)
 		(uuid "84c3f1c7-2fd1-4046-81df-98a99adc81e5")
 		(property "Reference" "L3"
-			(at 910.082 353.568 0)
+			(at 841.502 404.368 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -81997,7 +92494,7 @@
 			)
 		)
 		(property "Value" "120nH"
-			(at 911.86 355.854 0)
+			(at 843.28 406.654 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -82006,7 +92503,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 911.86 355.6 0)
+			(at 843.28 406.4 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -82015,7 +92512,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 911.86 355.6 0)
+			(at 843.28 406.4 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -82024,7 +92521,7 @@
 			)
 		)
 		(property "Description" "Inductor"
-			(at 911.86 355.6 0)
+			(at 843.28 406.4 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -82058,7 +92555,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "8535a1a7-f835-4b47-9472-deeada1b543d")
-		(property "Reference" "#PWR0335"
+		(property "Reference" "#PWR335"
 			(at 137.16 309.88 0)
 			(effects
 				(font
@@ -82108,7 +92605,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0335")
+					(reference "#PWR335")
 					(unit 1)
 				)
 			)
@@ -82124,7 +92621,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "85373708-aa57-4526-8375-8f6a67d94530")
-		(property "Reference" "#PWR097"
+		(property "Reference" "#PWR97"
 			(at 222.25 118.11 0)
 			(effects
 				(font
@@ -82175,7 +92672,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR097")
+					(reference "#PWR97")
 					(unit 1)
 				)
 			)
@@ -82252,7 +92749,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 628.65 412.75 90)
+		(at 748.03 401.32 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -82260,7 +92757,7 @@
 		(dnp no)
 		(uuid "8618137b-de5c-4e5f-a4cc-547512a8ee49")
 		(property "Reference" "R20"
-			(at 630.174 410.464 90)
+			(at 749.554 399.034 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -82268,7 +92765,7 @@
 			)
 		)
 		(property "Value" "1k"
-			(at 626.872 410.464 90)
+			(at 746.252 399.034 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -82276,7 +92773,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 628.904 411.734 90)
+			(at 748.284 400.304 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -82285,7 +92782,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 628.65 412.75 0)
+			(at 748.03 401.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -82294,7 +92791,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 628.65 412.75 0)
+			(at 748.03 401.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -82750,7 +93247,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "89c4015b-1bb1-4b21-8e57-c8675ff5077b")
-		(property "Reference" "#PWR010"
+		(property "Reference" "#PWR10"
 			(at 669.29 69.85 0)
 			(effects
 				(font
@@ -82801,7 +93298,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR010")
+					(reference "#PWR10")
 					(unit 1)
 				)
 			)
@@ -82887,7 +93384,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "8a038577-2d8a-40d1-afbd-9453ff9b7fc1")
-		(property "Reference" "#PWR08"
+		(property "Reference" "#PWR8"
 			(at 669.29 64.77 0)
 			(effects
 				(font
@@ -82938,7 +93435,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR08")
+					(reference "#PWR8")
 					(unit 1)
 				)
 			)
@@ -82954,7 +93451,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "8a2a6a55-d4c1-4682-958c-469aa0ed12b2")
-		(property "Reference" "#PWR0279"
+		(property "Reference" "#PWR279"
 			(at 622.3 132.08 0)
 			(effects
 				(font
@@ -83005,7 +93502,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0279")
+					(reference "#PWR279")
 					(unit 1)
 				)
 			)
@@ -83013,7 +93510,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 558.8 394.97 0)
+		(at 678.18 383.54 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -83021,8 +93518,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "8a2e0b22-cecf-48f1-a998-1e3352ec671f")
-		(property "Reference" "#PWR0126"
-			(at 558.8 401.32 0)
+		(property "Reference" "#PWR126"
+			(at 678.18 389.89 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -83031,7 +93528,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 558.8 400.05 0)
+			(at 678.18 388.62 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -83040,7 +93537,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 558.8 394.97 0)
+			(at 678.18 383.54 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -83049,7 +93546,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 558.8 394.97 0)
+			(at 678.18 383.54 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -83058,7 +93555,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 558.8 394.97 0)
+			(at 678.18 383.54 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -83072,7 +93569,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0126")
+					(reference "#PWR126")
 					(unit 1)
 				)
 			)
@@ -83155,7 +93652,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "8a4d4966-b88f-49a6-a5e8-adce02245306")
-		(property "Reference" "#PWR094"
+		(property "Reference" "#PWR94"
 			(at 297.18 212.09 0)
 			(effects
 				(font
@@ -83206,7 +93703,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR094")
+					(reference "#PWR94")
 					(unit 1)
 				)
 			)
@@ -83284,7 +93781,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 712.47 355.6 0)
+		(at 642.62 410.21 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -83292,8 +93789,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "8b02a904-ab78-4288-9725-55d5e9b2de3e")
-		(property "Reference" "#PWR0113"
-			(at 712.47 361.95 0)
+		(property "Reference" "#PWR113"
+			(at 642.62 416.56 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -83302,7 +93799,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 712.4701 359.41 90)
+			(at 642.6201 414.02 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -83312,7 +93809,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 712.47 355.6 0)
+			(at 642.62 410.21 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -83321,7 +93818,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 712.47 355.6 0)
+			(at 642.62 410.21 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -83330,7 +93827,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 712.47 355.6 0)
+			(at 642.62 410.21 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -83344,7 +93841,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0113")
+					(reference "#PWR113")
 					(unit 1)
 				)
 			)
@@ -83421,7 +93918,7 @@
 	)
 	(symbol
 		(lib_id "power:PWR_FLAG")
-		(at 594.36 246.38 0)
+		(at 666.75 246.38 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -83430,7 +93927,7 @@
 		(fields_autoplaced yes)
 		(uuid "8bfdfceb-36b9-4295-ab1c-0a993de50586")
 		(property "Reference" "#FLG010"
-			(at 594.36 244.475 0)
+			(at 666.75 244.475 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -83439,7 +93936,7 @@
 			)
 		)
 		(property "Value" "PWR_FLAG"
-			(at 594.36 241.3 0)
+			(at 666.75 241.3 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -83447,7 +93944,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 594.36 246.38 0)
+			(at 666.75 246.38 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -83456,7 +93953,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 594.36 246.38 0)
+			(at 666.75 246.38 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -83465,7 +93962,7 @@
 			)
 		)
 		(property "Description" "Special symbol for telling ERC where power comes from"
-			(at 594.36 246.38 0)
+			(at 666.75 246.38 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -83564,7 +94061,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "8c87a10f-a179-4686-a7f0-a6af4a0aa54c")
-		(property "Reference" "#PWR0349"
+		(property "Reference" "#PWR349"
 			(at 297.18 275.59 0)
 			(effects
 				(font
@@ -83615,7 +94112,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0349")
+					(reference "#PWR349")
 					(unit 1)
 				)
 			)
@@ -83632,7 +94129,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "8c9dc779-7780-4bc3-aea9-b40794fdfb49")
-		(property "Reference" "#PWR0252"
+		(property "Reference" "#PWR252"
 			(at 138.43 233.68 0)
 			(effects
 				(font
@@ -83682,7 +94179,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0252")
+					(reference "#PWR252")
 					(unit 1)
 				)
 			)
@@ -83757,7 +94254,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 541.02 322.58 180)
+		(at 494.03 379.73 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -83765,7 +94262,7 @@
 		(dnp no)
 		(uuid "8d7196cc-306d-4cbc-bc01-6805c5e486d0")
 		(property "Reference" "R12"
-			(at 538.988 323.596 0)
+			(at 491.998 380.746 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -83774,7 +94271,7 @@
 			)
 		)
 		(property "Value" "500"
-			(at 538.988 321.564 0)
+			(at 491.998 378.714 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -83783,7 +94280,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 540.004 322.326 90)
+			(at 493.014 379.476 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -83792,7 +94289,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 541.02 322.58 0)
+			(at 494.03 379.73 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -83801,7 +94298,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 541.02 322.58 0)
+			(at 494.03 379.73 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -83973,7 +94470,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "8e87d04b-9b85-48e1-9321-7bcc36cf471d")
-		(property "Reference" "#PWR0211"
+		(property "Reference" "#PWR211"
 			(at 87.63 582.93 0)
 			(effects
 				(font
@@ -84023,7 +94520,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0211")
+					(reference "#PWR211")
 					(unit 1)
 				)
 			)
@@ -84031,7 +94528,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 796.29 351.79 0)
+		(at 693.42 351.79 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -84039,7 +94536,7 @@
 		(dnp no)
 		(uuid "8eec9799-805d-4a47-a254-e405b565c038")
 		(property "Reference" "C144"
-			(at 790.702 349.758 0)
+			(at 687.832 349.758 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -84048,7 +94545,7 @@
 			)
 		)
 		(property "Value" "3.3pF"
-			(at 796.798 349.758 0)
+			(at 693.928 349.758 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -84057,7 +94554,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 797.2552 355.6 0)
+			(at 694.3852 355.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -84066,7 +94563,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 796.29 351.79 0)
+			(at 693.42 351.79 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -84075,7 +94572,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 796.29 351.79 0)
+			(at 693.42 351.79 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -84100,7 +94597,7 @@
 	)
 	(symbol
 		(lib_id "LIB_IRISHSAT:ADA4940-2ACPZ-R7")
-		(at 702.31 322.58 0)
+		(at 632.46 377.19 0)
 		(mirror y)
 		(unit 1)
 		(exclude_from_sim no)
@@ -84109,7 +94606,7 @@
 		(dnp no)
 		(uuid "8eed798b-f06a-4e12-ae06-71b220472364")
 		(property "Reference" "U7"
-			(at 676.91 312.42 0)
+			(at 607.06 367.03 0)
 			(effects
 				(font
 					(size 1.524 1.524)
@@ -84117,7 +94614,7 @@
 			)
 		)
 		(property "Value" "ADA4940-2ACPZ-R7"
-			(at 676.91 314.96 0)
+			(at 607.06 369.57 0)
 			(effects
 				(font
 					(size 1.524 1.524)
@@ -84125,7 +94622,7 @@
 			)
 		)
 		(property "Footprint" "LIB_IRISHSAT:CP_24_7_ADI"
-			(at 702.31 322.58 0)
+			(at 632.46 377.19 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -84135,7 +94632,7 @@
 			)
 		)
 		(property "Datasheet" "https://www.analog.com/media/en/technical-documentation/data-sheets/ada4940-1_4940-2.pdf"
-			(at 702.31 322.58 0)
+			(at 632.46 377.19 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -84145,7 +94642,7 @@
 			)
 		)
 		(property "Description" ""
-			(at 702.31 322.58 0)
+			(at 632.46 377.19 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -84394,7 +94891,7 @@
 	)
 	(symbol
 		(lib_id "power:+5V")
-		(at 702.31 345.44 270)
+		(at 632.46 400.05 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -84403,7 +94900,7 @@
 		(fields_autoplaced yes)
 		(uuid "8ff39a19-c6f4-4556-a1e5-2faf3a6b0c0f")
 		(property "Reference" "#PWR0265"
-			(at 698.5 345.44 0)
+			(at 628.65 400.05 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -84412,7 +94909,7 @@
 			)
 		)
 		(property "Value" "+5V"
-			(at 706.12 345.4399 90)
+			(at 636.27 400.0499 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -84421,7 +94918,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 702.31 345.44 0)
+			(at 632.46 400.05 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -84430,7 +94927,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 702.31 345.44 0)
+			(at 632.46 400.05 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -84439,7 +94936,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"+5V\""
-			(at 702.31 345.44 0)
+			(at 632.46 400.05 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -84469,7 +94966,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "8ffd086f-e338-415e-81a4-d04b8e6d7196")
-		(property "Reference" "#PWR058"
+		(property "Reference" "#PWR58"
 			(at 1004.57 708.66 0)
 			(effects
 				(font
@@ -84519,7 +95016,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR058")
+					(reference "#PWR58")
 					(unit 1)
 				)
 			)
@@ -84535,7 +95032,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "905cf0e5-f162-4d15-8caf-987f31331bb9")
-		(property "Reference" "#PWR069"
+		(property "Reference" "#PWR69"
 			(at 897.89 615.95 0)
 			(effects
 				(font
@@ -84585,7 +95082,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR069")
+					(reference "#PWR69")
 					(unit 1)
 				)
 			)
@@ -84795,7 +95292,7 @@
 	)
 	(symbol
 		(lib_id "power:+3V3")
-		(at 516.89 220.98 270)
+		(at 614.68 255.27 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -84804,7 +95301,7 @@
 		(fields_autoplaced yes)
 		(uuid "92e12d54-a602-4a84-b473-5a667b579988")
 		(property "Reference" "#PWR0243"
-			(at 513.08 220.98 0)
+			(at 610.87 255.27 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -84813,7 +95310,7 @@
 			)
 		)
 		(property "Value" "+3V3"
-			(at 520.7 220.9799 90)
+			(at 618.49 255.2699 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -84822,7 +95319,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 516.89 220.98 0)
+			(at 614.68 255.27 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -84831,7 +95328,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 516.89 220.98 0)
+			(at 614.68 255.27 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -84840,7 +95337,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"+3V3\""
-			(at 516.89 220.98 0)
+			(at 614.68 255.27 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -84862,7 +95359,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 814.07 330.2 180)
+		(at 711.2 330.2 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -84870,8 +95367,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "930a372d-353f-4df8-a567-cf3568d5a4e0")
-		(property "Reference" "#PWR0317"
-			(at 814.07 323.85 0)
+		(property "Reference" "#PWR317"
+			(at 711.2 323.85 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -84880,7 +95377,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 814.07 325.12 0)
+			(at 711.2 325.12 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -84889,7 +95386,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 814.07 330.2 0)
+			(at 711.2 330.2 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -84898,7 +95395,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 814.07 330.2 0)
+			(at 711.2 330.2 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -84907,7 +95404,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 814.07 330.2 0)
+			(at 711.2 330.2 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -84921,7 +95418,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0317")
+					(reference "#PWR317")
 					(unit 1)
 				)
 			)
@@ -84937,7 +95434,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "9377f972-ac48-4a46-9ee5-0074f2b11d0b")
-		(property "Reference" "#PWR086"
+		(property "Reference" "#PWR86"
 			(at 322.58 648.97 0)
 			(effects
 				(font
@@ -84987,7 +95484,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR086")
+					(reference "#PWR86")
 					(unit 1)
 				)
 			)
@@ -85064,7 +95561,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 674.37 220.98 0)
+		(at 746.76 220.98 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -85072,8 +95569,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "9471e1bd-253a-4b9b-b609-a287d7afa54a")
-		(property "Reference" "#PWR0238"
-			(at 674.37 227.33 0)
+		(property "Reference" "#PWR238"
+			(at 746.76 227.33 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -85082,7 +95579,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 674.37 226.06 0)
+			(at 746.76 226.06 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -85090,7 +95587,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 674.37 220.98 0)
+			(at 746.76 220.98 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -85099,7 +95596,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 674.37 220.98 0)
+			(at 746.76 220.98 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -85108,7 +95605,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 674.37 220.98 0)
+			(at 746.76 220.98 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -85122,7 +95619,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0238")
+					(reference "#PWR238")
 					(unit 1)
 				)
 			)
@@ -85200,7 +95697,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 651.51 347.98 270)
+		(at 581.66 402.59 270)
 		(mirror x)
 		(unit 1)
 		(exclude_from_sim no)
@@ -85209,8 +95706,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "94e30853-ca88-4ae7-93f4-42f34ae277c2")
-		(property "Reference" "#PWR0137"
-			(at 645.16 347.98 0)
+		(property "Reference" "#PWR137"
+			(at 575.31 402.59 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -85219,7 +95716,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 647.7 347.9799 90)
+			(at 577.85 402.5899 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -85229,7 +95726,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 651.51 347.98 0)
+			(at 581.66 402.59 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -85238,7 +95735,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 651.51 347.98 0)
+			(at 581.66 402.59 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -85247,7 +95744,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 651.51 347.98 0)
+			(at 581.66 402.59 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -85261,7 +95758,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0137")
+					(reference "#PWR137")
 					(unit 1)
 				)
 			)
@@ -85269,7 +95766,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 796.29 334.01 0)
+		(at 693.42 334.01 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -85277,7 +95774,7 @@
 		(dnp no)
 		(uuid "954daf1c-6ccd-44b6-b549-506b59b5c9a9")
 		(property "Reference" "C143"
-			(at 788.416 332.74 0)
+			(at 685.546 332.74 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -85286,7 +95783,7 @@
 			)
 		)
 		(property "Value" "3.3pF"
-			(at 788.416 335.28 0)
+			(at 685.546 335.28 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -85295,7 +95792,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 797.2552 337.82 0)
+			(at 694.3852 337.82 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -85304,7 +95801,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 796.29 334.01 0)
+			(at 693.42 334.01 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -85313,7 +95810,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 796.29 334.01 0)
+			(at 693.42 334.01 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -85338,7 +95835,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 452.12 401.32 0)
+		(at 410.21 426.72 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -85346,8 +95843,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "95ae8cff-8c1f-43d4-b1fc-c59813495510")
-		(property "Reference" "#PWR045"
-			(at 452.12 407.67 0)
+		(property "Reference" "#PWR45"
+			(at 410.21 433.07 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -85356,7 +95853,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 452.12 406.4 0)
+			(at 410.21 431.8 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -85365,7 +95862,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 452.12 401.32 0)
+			(at 410.21 426.72 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -85374,7 +95871,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 452.12 401.32 0)
+			(at 410.21 426.72 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -85383,7 +95880,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 452.12 401.32 0)
+			(at 410.21 426.72 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -85397,13 +95894,14 @@
 		(instances
 			(project ""
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR045")
+					(reference "#PWR45")
 					(unit 1)
 				)
 			)
 		)
 	)
 	(symbol
+		(lib_name "XC7A35T-1FTG256C_1")
 		(lib_id "LIB_IRISHSAT:XC7A35T-1FTG256C")
 		(at 228.6 59.69 0)
 		(unit 1)
@@ -86237,7 +96735,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 449.58 416.56 0)
+		(at 407.67 441.96 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -86245,7 +96743,7 @@
 		(dnp no)
 		(uuid "973aa584-c26d-4c01-9a19-f0fe475b7358")
 		(property "Reference" "C122"
-			(at 446.024 413.7661 90)
+			(at 404.114 439.1661 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -86254,7 +96752,7 @@
 			)
 		)
 		(property "Value" "0.1uF"
-			(at 443.992 413.766 90)
+			(at 402.082 439.166 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -86263,7 +96761,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 450.5452 420.37 0)
+			(at 408.6352 445.77 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -86272,7 +96770,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 449.58 416.56 0)
+			(at 407.67 441.96 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -86281,7 +96779,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 449.58 416.56 0)
+			(at 407.67 441.96 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -86582,7 +97080,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "99ae1b68-4e76-42c4-9593-0c293b4442e8")
-		(property "Reference" "#PWR033"
+		(property "Reference" "#PWR33"
 			(at 318.77 314.96 0)
 			(effects
 				(font
@@ -86633,7 +97131,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR033")
+					(reference "#PWR33")
 					(unit 1)
 				)
 			)
@@ -86641,7 +97139,7 @@
 	)
 	(symbol
 		(lib_id "LIB_IRISHSAT:ETC1-1-13TR")
-		(at 949.96 359.41 180)
+		(at 881.38 410.21 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -86650,7 +97148,7 @@
 		(fields_autoplaced yes)
 		(uuid "9a220ca3-4d48-46db-b558-dbc2b678c781")
 		(property "Reference" "T1"
-			(at 951.23 344.1699 0)
+			(at 882.65 394.9699 0)
 			(effects
 				(font
 					(size 1.524 1.524)
@@ -86659,7 +97157,7 @@
 			)
 		)
 		(property "Value" "ETC1-1-13TR"
-			(at 951.23 346.7099 0)
+			(at 882.65 397.5099 0)
 			(effects
 				(font
 					(size 1.524 1.524)
@@ -86668,7 +97166,7 @@
 			)
 		)
 		(property "Footprint" "LIB_IRISHSAT:ETC1-1-13TR_MCM"
-			(at 949.96 359.41 0)
+			(at 881.38 410.21 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -86678,7 +97176,7 @@
 			)
 		)
 		(property "Datasheet" "ETC1-1-13TR"
-			(at 949.96 359.41 0)
+			(at 881.38 410.21 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -86688,7 +97186,7 @@
 			)
 		)
 		(property "Description" ""
-			(at 949.96 359.41 0)
+			(at 881.38 410.21 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -87001,7 +97499,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "9b11a917-ad4c-43db-98e8-dcdbd7be30b1")
-		(property "Reference" "#PWR0246"
+		(property "Reference" "#PWR246"
 			(at 137.16 66.04 0)
 			(effects
 				(font
@@ -87052,7 +97550,7 @@
 		(instances
 			(project ""
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0246")
+					(reference "#PWR246")
 					(unit 1)
 				)
 			)
@@ -87060,7 +97558,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 661.67 410.21 0)
+		(at 781.05 398.78 0)
 		(mirror y)
 		(unit 1)
 		(exclude_from_sim no)
@@ -87069,7 +97567,7 @@
 		(dnp no)
 		(uuid "9b743a6b-260d-48df-bbc6-ad61c5e44663")
 		(property "Reference" "C50"
-			(at 668.02 408.432 0)
+			(at 787.4 397.002 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -87078,7 +97576,7 @@
 			)
 		)
 		(property "Value" ".1uF"
-			(at 668.528 410.21 0)
+			(at 787.908 398.78 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -87087,7 +97585,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 660.7048 414.02 0)
+			(at 780.0848 402.59 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -87096,7 +97594,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 661.67 410.21 0)
+			(at 781.05 398.78 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -87105,7 +97603,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 661.67 410.21 0)
+			(at 781.05 398.78 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -87208,7 +97706,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "9b83be56-f5d4-410e-b71d-63b688b4921d")
-		(property "Reference" "#PWR055"
+		(property "Reference" "#PWR55"
 			(at 979.17 674.37 0)
 			(effects
 				(font
@@ -87259,7 +97757,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR055")
+					(reference "#PWR55")
 					(unit 1)
 				)
 			)
@@ -87404,7 +97902,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 598.17 250.19 0)
+		(at 670.56 250.19 0)
 		(mirror y)
 		(unit 1)
 		(exclude_from_sim no)
@@ -87413,7 +97911,7 @@
 		(dnp no)
 		(uuid "9ccec13f-f201-4fd3-a930-fc601e4b961e")
 		(property "Reference" "C90"
-			(at 594.614 249.682 0)
+			(at 667.004 249.682 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -87422,7 +97920,7 @@
 			)
 		)
 		(property "Value" "1uF"
-			(at 594.36 251.4599 0)
+			(at 666.75 251.4599 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -87431,7 +97929,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 597.2048 254 0)
+			(at 669.5948 254 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -87440,7 +97938,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 598.17 250.19 0)
+			(at 670.56 250.19 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -87449,7 +97947,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 598.17 250.19 0)
+			(at 670.56 250.19 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -87482,7 +97980,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "9db762d8-3682-4b39-9773-02ec72b1bbcc")
-		(property "Reference" "#PWR091"
+		(property "Reference" "#PWR91"
 			(at 222.25 207.01 0)
 			(effects
 				(font
@@ -87533,7 +98031,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR091")
+					(reference "#PWR91")
 					(unit 1)
 				)
 			)
@@ -87549,7 +98047,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "9dbc5b0f-5c00-4877-b9f1-1adde62642b1")
-		(property "Reference" "#PWR0153"
+		(property "Reference" "#PWR153"
 			(at 605.79 76.2 0)
 			(effects
 				(font
@@ -87600,7 +98098,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0153")
+					(reference "#PWR153")
 					(unit 1)
 				)
 			)
@@ -87746,7 +98244,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 844.55 337.82 90)
+		(at 741.68 337.82 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -87754,7 +98252,7 @@
 		(dnp no)
 		(uuid "a0ba4db5-91d6-48b4-8d60-74004ceaa17e")
 		(property "Reference" "C150"
-			(at 844.55 331.978 90)
+			(at 741.68 331.978 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -87762,7 +98260,7 @@
 			)
 		)
 		(property "Value" "1nF"
-			(at 844.55 334.518 90)
+			(at 741.68 334.518 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -87770,7 +98268,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 848.36 336.8548 0)
+			(at 745.49 336.8548 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -87779,7 +98277,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 844.55 337.82 0)
+			(at 741.68 337.82 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -87788,7 +98286,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 844.55 337.82 0)
+			(at 741.68 337.82 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -87888,7 +98386,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "a28c0935-9820-4bdc-96ec-0db4dd511c47")
-		(property "Reference" "#PWR0156"
+		(property "Reference" "#PWR156"
 			(at 497.84 153.67 0)
 			(effects
 				(font
@@ -87939,7 +98437,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0156")
+					(reference "#PWR156")
 					(unit 1)
 				)
 			)
@@ -88022,7 +98520,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "a31fe2d8-ebd4-4b7b-879b-a3c24e5dddd9")
-		(property "Reference" "#PWR083"
+		(property "Reference" "#PWR83"
 			(at 154.94 690.88 0)
 			(effects
 				(font
@@ -88072,7 +98570,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR083")
+					(reference "#PWR83")
 					(unit 1)
 				)
 			)
@@ -88147,7 +98645,7 @@
 	)
 	(symbol
 		(lib_id "power:+3V3")
-		(at 449.58 326.39 0)
+		(at 407.67 351.79 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -88156,7 +98654,7 @@
 		(fields_autoplaced yes)
 		(uuid "a3ad8112-b8ac-4f1f-83ea-f500b56a1e37")
 		(property "Reference" "#PWR0269"
-			(at 449.58 330.2 0)
+			(at 407.67 355.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -88165,7 +98663,7 @@
 			)
 		)
 		(property "Value" "+3V"
-			(at 449.58 321.31 0)
+			(at 407.67 346.71 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -88173,7 +98671,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 449.58 326.39 0)
+			(at 407.67 351.79 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -88182,7 +98680,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 449.58 326.39 0)
+			(at 407.67 351.79 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -88191,7 +98689,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"+3V3\""
-			(at 449.58 326.39 0)
+			(at 407.67 351.79 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -88286,7 +98784,7 @@
 	)
 	(symbol
 		(lib_id "LIB_IRISHSAT:AD9218BSTZ-65")
-		(at 436.88 355.6 0)
+		(at 394.97 381 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -88294,7 +98792,7 @@
 		(dnp no)
 		(uuid "a46599a1-f71a-4176-b558-2eb81677cc76")
 		(property "Reference" "IC2"
-			(at 482.092 336.296 0)
+			(at 440.182 361.696 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -88302,7 +98800,7 @@
 			)
 		)
 		(property "Value" "AD9218BSTZ-65"
-			(at 482.092 338.836 0)
+			(at 440.182 364.236 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -88310,7 +98808,7 @@
 			)
 		)
 		(property "Footprint" "LIB_IRISHSAT:QFP50P900X900X160-48N"
-			(at 476.25 437.82 0)
+			(at 434.34 463.22 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -88320,7 +98818,7 @@
 			)
 		)
 		(property "Datasheet" "https://www.analog.com/AD9218/datasheet"
-			(at 476.25 537.82 0)
+			(at 434.34 563.22 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -88330,7 +98828,7 @@
 			)
 		)
 		(property "Description" "10-Bit, 40/65/80/105 MSPS 3 V Dual Analog-to-Digital Converter"
-			(at 436.88 355.6 0)
+			(at 394.97 381 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -88339,7 +98837,7 @@
 			)
 		)
 		(property "Height" "1.6"
-			(at 476.25 737.82 0)
+			(at 434.34 763.22 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -88349,7 +98847,7 @@
 			)
 		)
 		(property "Manufacturer_Name" "Analog Devices"
-			(at 476.25 837.82 0)
+			(at 434.34 863.22 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -88359,7 +98857,7 @@
 			)
 		)
 		(property "Manufacturer_Part_Number" "AD9218BSTZ-65"
-			(at 476.25 937.82 0)
+			(at 434.34 963.22 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -88369,7 +98867,7 @@
 			)
 		)
 		(property "Mouser Part Number" "584-AD9218BSTZ-65"
-			(at 476.25 1037.82 0)
+			(at 434.34 1063.22 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -88379,7 +98877,7 @@
 			)
 		)
 		(property "Mouser Price/Stock" "https://www.mouser.co.uk/ProductDetail/Analog-Devices/AD9218BSTZ-65?qs=%2FtpEQrCGXCyCWFYnAH7IIg%3D%3D"
-			(at 476.25 1137.82 0)
+			(at 434.34 1163.22 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -88389,7 +98887,7 @@
 			)
 		)
 		(property "Arrow Part Number" "AD9218BSTZ-65"
-			(at 476.25 1237.82 0)
+			(at 434.34 1263.22 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -88399,7 +98897,7 @@
 			)
 		)
 		(property "Arrow Price/Stock" "https://www.arrow.com/en/products/ad9218bstz-65/analog-devices"
-			(at 476.25 1337.82 0)
+			(at 434.34 1363.22 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -88563,7 +99061,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 641.35 170.18 270)
+		(at 713.74 170.18 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -88571,7 +99069,7 @@
 		(dnp no)
 		(uuid "a4e3bfbd-8251-4055-a810-05808c173d24")
 		(property "Reference" "C55"
-			(at 639.572 163.322 90)
+			(at 711.962 163.322 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -88579,7 +99077,7 @@
 			)
 		)
 		(property "Value" "1uF"
-			(at 639.826 166.116 90)
+			(at 712.216 166.116 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -88587,7 +99085,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 637.54 171.1452 0)
+			(at 709.93 171.1452 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -88596,7 +99094,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 641.35 170.18 0)
+			(at 713.74 170.18 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -88605,7 +99103,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 641.35 170.18 0)
+			(at 713.74 170.18 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -88630,7 +99128,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 514.35 241.3 0)
+		(at 612.14 275.59 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -88638,8 +99136,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "a58b18c8-f4f0-4b3e-9457-3845694ae1d0")
-		(property "Reference" "#PWR0244"
-			(at 514.35 247.65 0)
+		(property "Reference" "#PWR244"
+			(at 612.14 281.94 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -88648,7 +99146,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 514.35 246.38 0)
+			(at 612.14 280.67 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -88656,7 +99154,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 514.35 241.3 0)
+			(at 612.14 275.59 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -88665,7 +99163,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 514.35 241.3 0)
+			(at 612.14 275.59 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -88674,7 +99172,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 514.35 241.3 0)
+			(at 612.14 275.59 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -88688,7 +99186,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0244")
+					(reference "#PWR244")
 					(unit 1)
 				)
 			)
@@ -88696,7 +99194,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 490.22 363.22 0)
+		(at 448.31 388.62 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -88704,7 +99202,7 @@
 		(dnp no)
 		(uuid "a5c0b9f7-86ef-49e5-ae57-6e483d86de61")
 		(property "Reference" "C2"
-			(at 494.03 361.9499 0)
+			(at 452.12 387.3499 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -88713,7 +99211,7 @@
 			)
 		)
 		(property "Value" "0.1uF"
-			(at 494.03 364.4899 0)
+			(at 452.12 389.8899 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -88722,7 +99220,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 491.1852 367.03 0)
+			(at 449.2752 392.43 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -88731,7 +99229,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 490.22 363.22 0)
+			(at 448.31 388.62 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -88740,7 +99238,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 490.22 363.22 0)
+			(at 448.31 388.62 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -88765,7 +99263,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 814.07 355.6 0)
+		(at 711.2 355.6 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -88773,8 +99271,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "a6337e78-ed51-47ae-b3a8-76cbeacb0708")
-		(property "Reference" "#PWR0318"
-			(at 814.07 361.95 0)
+		(property "Reference" "#PWR318"
+			(at 711.2 361.95 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -88783,7 +99281,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 814.07 360.68 0)
+			(at 711.2 360.68 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -88792,7 +99290,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 814.07 355.6 0)
+			(at 711.2 355.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -88801,7 +99299,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 814.07 355.6 0)
+			(at 711.2 355.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -88810,7 +99308,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 814.07 355.6 0)
+			(at 711.2 355.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -88824,7 +99322,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0318")
+					(reference "#PWR318")
 					(unit 1)
 				)
 			)
@@ -88840,7 +99338,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "a68e2d7c-81eb-4403-8725-b33294dde895")
-		(property "Reference" "#PWR0282"
+		(property "Reference" "#PWR282"
 			(at 137.16 60.96 0)
 			(effects
 				(font
@@ -88891,7 +99389,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0282")
+					(reference "#PWR282")
 					(unit 1)
 				)
 			)
@@ -88907,7 +99405,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "a69ad750-3f8b-46a7-a856-910fee929f1e")
-		(property "Reference" "#PWR021"
+		(property "Reference" "#PWR21"
 			(at 960.12 138.43 0)
 			(effects
 				(font
@@ -88958,7 +99456,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR021")
+					(reference "#PWR21")
 					(unit 1)
 				)
 			)
@@ -88966,7 +99464,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 491.49 379.73 0)
+		(at 449.58 405.13 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -88974,7 +99472,7 @@
 		(dnp no)
 		(uuid "a6e0816d-4c03-415e-983d-da36c06204f9")
 		(property "Reference" "C121"
-			(at 495.3 378.4599 0)
+			(at 453.39 403.8599 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -88983,7 +99481,7 @@
 			)
 		)
 		(property "Value" "0.1uF"
-			(at 495.3 380.9999 0)
+			(at 453.39 406.3999 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -88992,7 +99490,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 492.4552 383.54 0)
+			(at 450.5452 408.94 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -89001,7 +99499,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 491.49 379.73 0)
+			(at 449.58 405.13 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -89010,7 +99508,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 491.49 379.73 0)
+			(at 449.58 405.13 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -89035,7 +99533,7 @@
 	)
 	(symbol
 		(lib_id "Device:L")
-		(at 557.53 354.33 270)
+		(at 510.54 411.48 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -89044,7 +99542,7 @@
 		(fields_autoplaced yes)
 		(uuid "a70c3b1c-213b-4388-837a-aacede7e3afd")
 		(property "Reference" "L14"
-			(at 557.53 359.41 90)
+			(at 510.54 416.56 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -89052,7 +99550,7 @@
 			)
 		)
 		(property "Value" "10uH"
-			(at 557.53 356.87 90)
+			(at 510.54 414.02 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -89060,7 +99558,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 557.53 354.33 0)
+			(at 510.54 411.48 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -89069,7 +99567,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 557.53 354.33 0)
+			(at 510.54 411.48 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -89078,7 +99576,7 @@
 			)
 		)
 		(property "Description" "Inductor"
-			(at 557.53 354.33 0)
+			(at 510.54 411.48 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -89310,7 +99808,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 436.88 355.6 270)
+		(at 394.97 381 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -89318,8 +99816,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "a9802310-3f66-4c47-b8fd-7ce8414fde27")
-		(property "Reference" "#PWR047"
-			(at 430.53 355.6 0)
+		(property "Reference" "#PWR47"
+			(at 388.62 381 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -89328,7 +99826,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 433.07 355.5999 90)
+			(at 391.16 380.9999 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -89338,7 +99836,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 436.88 355.6 0)
+			(at 394.97 381 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -89347,7 +99845,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 436.88 355.6 0)
+			(at 394.97 381 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -89356,7 +99854,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 436.88 355.6 0)
+			(at 394.97 381 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -89370,7 +99868,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR047")
+					(reference "#PWR47")
 					(unit 1)
 				)
 			)
@@ -89535,7 +100033,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "a9ba5b53-115e-4fbc-9af6-6fabc09dd9b6")
-		(property "Reference" "#PWR01"
+		(property "Reference" "#PWR1"
 			(at 669.29 46.99 0)
 			(effects
 				(font
@@ -89586,7 +100084,7 @@
 		(instances
 			(project ""
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR01")
+					(reference "#PWR1")
 					(unit 1)
 				)
 			)
@@ -89603,7 +100101,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "aa1a5f9b-7457-4fc9-ad3e-b2e9f3367778")
-		(property "Reference" "#PWR0338"
+		(property "Reference" "#PWR338"
 			(at 137.16 368.3 0)
 			(effects
 				(font
@@ -89653,7 +100151,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0338")
+					(reference "#PWR338")
 					(unit 1)
 				)
 			)
@@ -89669,7 +100167,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "aa221906-ca5d-4d62-b363-e34e229ae4e9")
-		(property "Reference" "#PWR05"
+		(property "Reference" "#PWR5"
 			(at 669.29 57.15 0)
 			(effects
 				(font
@@ -89720,7 +100218,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR05")
+					(reference "#PWR5")
 					(unit 1)
 				)
 			)
@@ -89728,7 +100226,7 @@
 	)
 	(symbol
 		(lib_id "LIB_IRISHSAT:ADL5387ACPZ-R7")
-		(at 582.93 389.89 0)
+		(at 702.31 378.46 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -89737,7 +100235,7 @@
 		(fields_autoplaced yes)
 		(uuid "aabc9948-55a9-40f2-ad6f-e6dcf399568f")
 		(property "Reference" "U12"
-			(at 603.25 379.73 0)
+			(at 722.63 368.3 0)
 			(effects
 				(font
 					(size 1.524 1.524)
@@ -89745,7 +100243,7 @@
 			)
 		)
 		(property "Value" "ADL5387ACPZ-R7"
-			(at 603.25 382.27 0)
+			(at 722.63 370.84 0)
 			(effects
 				(font
 					(size 1.524 1.524)
@@ -89753,7 +100251,7 @@
 			)
 		)
 		(property "Footprint" "LIB_IRISHSAT:CP-24-14_ADI"
-			(at 582.93 389.89 0)
+			(at 702.31 378.46 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -89763,7 +100261,7 @@
 			)
 		)
 		(property "Datasheet" "https://www.analog.com/media/en/technical-documentation/data-sheets/ADL5387.pdf"
-			(at 582.93 389.89 0)
+			(at 702.31 378.46 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -89773,7 +100271,7 @@
 			)
 		)
 		(property "Description" ""
-			(at 582.93 389.89 0)
+			(at 702.31 378.46 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -89867,7 +100365,7 @@
 	)
 	(symbol
 		(lib_id "power:+3V3")
-		(at 511.81 369.57 0)
+		(at 469.9 394.97 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -89875,7 +100373,7 @@
 		(dnp no)
 		(uuid "ab04c7a6-912e-494e-8cd5-be15025fbbda")
 		(property "Reference" "#PWR0293"
-			(at 511.81 373.38 0)
+			(at 469.9 398.78 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -89884,7 +100382,7 @@
 			)
 		)
 		(property "Value" "+3V"
-			(at 511.81 365.76 0)
+			(at 469.9 391.16 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -89892,7 +100390,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 511.81 369.57 0)
+			(at 469.9 394.97 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -89901,7 +100399,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 511.81 369.57 0)
+			(at 469.9 394.97 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -89910,7 +100408,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"+3V3\""
-			(at 511.81 369.57 0)
+			(at 469.9 394.97 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -89940,7 +100438,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "ab9f143a-769e-4574-b712-f166c5daaffb")
-		(property "Reference" "#PWR099"
+		(property "Reference" "#PWR99"
 			(at 222.25 59.69 0)
 			(effects
 				(font
@@ -89991,7 +100489,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR099")
+					(reference "#PWR99")
 					(unit 1)
 				)
 			)
@@ -90007,7 +100505,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "abd8a532-467f-4088-8cfb-32cfcf902f22")
-		(property "Reference" "#PWR072"
+		(property "Reference" "#PWR72"
 			(at 817.88 605.79 0)
 			(effects
 				(font
@@ -90057,7 +100555,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR072")
+					(reference "#PWR72")
 					(unit 1)
 				)
 			)
@@ -90269,7 +100767,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 551.18 347.98 180)
+		(at 504.19 405.13 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -90277,7 +100775,7 @@
 		(dnp no)
 		(uuid "ace00628-0877-4a18-a8d3-f5df0613214e")
 		(property "Reference" "C42"
-			(at 548.132 348.742 0)
+			(at 501.142 405.892 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -90286,7 +100784,7 @@
 			)
 		)
 		(property "Value" "68pF"
-			(at 548.386 346.964 0)
+			(at 501.396 404.114 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -90295,7 +100793,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 550.2148 344.17 0)
+			(at 503.2248 401.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -90304,7 +100802,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 551.18 347.98 0)
+			(at 504.19 405.13 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -90313,7 +100811,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 551.18 347.98 0)
+			(at 504.19 405.13 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -90474,15 +100972,15 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 659.13 241.3 90)
+		(at 731.52 241.3 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
 		(uuid "ae58d3ba-e55e-4580-83ef-5f3f06aa3ab5")
-		(property "Reference" "#PWR0121"
-			(at 665.48 241.3 0)
+		(property "Reference" "#PWR121"
+			(at 737.87 241.3 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -90491,7 +100989,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 662.178 241.3 90)
+			(at 734.568 241.3 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -90500,7 +100998,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 659.13 241.3 0)
+			(at 731.52 241.3 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -90509,7 +101007,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 659.13 241.3 0)
+			(at 731.52 241.3 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -90518,7 +101016,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 659.13 241.3 0)
+			(at 731.52 241.3 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -90532,7 +101030,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0121")
+					(reference "#PWR121")
 					(unit 1)
 				)
 			)
@@ -90540,7 +101038,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 796.29 330.2 180)
+		(at 693.42 330.2 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -90548,8 +101046,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "ae68e064-3d4e-402f-b86b-7d507fc33e51")
-		(property "Reference" "#PWR0314"
-			(at 796.29 323.85 0)
+		(property "Reference" "#PWR314"
+			(at 693.42 323.85 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -90558,7 +101056,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 796.29 325.12 0)
+			(at 693.42 325.12 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -90567,7 +101065,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 796.29 330.2 0)
+			(at 693.42 330.2 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -90576,7 +101074,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 796.29 330.2 0)
+			(at 693.42 330.2 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -90585,7 +101083,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 796.29 330.2 0)
+			(at 693.42 330.2 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -90599,7 +101097,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0314")
+					(reference "#PWR314")
 					(unit 1)
 				)
 			)
@@ -90681,7 +101179,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "af0cb69b-8068-4cc7-ba75-5e4258fe6600")
-		(property "Reference" "#PWR040"
+		(property "Reference" "#PWR40"
 			(at 222.25 337.82 0)
 			(effects
 				(font
@@ -90732,7 +101230,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR040")
+					(reference "#PWR40")
 					(unit 1)
 				)
 			)
@@ -90809,7 +101307,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 626.11 288.29 0)
+		(at 698.5 288.29 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -90817,8 +101315,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "af25fd45-e573-4f94-beda-9155d245af74")
-		(property "Reference" "#PWR0140"
-			(at 626.11 294.64 0)
+		(property "Reference" "#PWR140"
+			(at 698.5 294.64 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -90827,7 +101325,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 626.11 293.37 0)
+			(at 698.5 293.37 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -90835,7 +101333,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 626.11 288.29 0)
+			(at 698.5 288.29 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -90844,7 +101342,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 626.11 288.29 0)
+			(at 698.5 288.29 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -90853,7 +101351,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 626.11 288.29 0)
+			(at 698.5 288.29 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -90867,7 +101365,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0140")
+					(reference "#PWR140")
 					(unit 1)
 				)
 			)
@@ -90944,7 +101442,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 631.19 274.32 0)
+		(at 703.58 274.32 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -90952,8 +101450,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "afb2c79e-179c-419d-bd62-e92672d91147")
-		(property "Reference" "#PWR0118"
-			(at 631.19 280.67 0)
+		(property "Reference" "#PWR118"
+			(at 703.58 280.67 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -90962,7 +101460,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 631.19 279.4 0)
+			(at 703.58 279.4 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -90970,7 +101468,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 631.19 274.32 0)
+			(at 703.58 274.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -90979,7 +101477,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 631.19 274.32 0)
+			(at 703.58 274.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -90988,7 +101486,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 631.19 274.32 0)
+			(at 703.58 274.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -91002,7 +101500,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0118")
+					(reference "#PWR118")
 					(unit 1)
 				)
 			)
@@ -91080,7 +101578,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 949.96 359.41 0)
+		(at 881.38 410.21 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -91088,8 +101586,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "affc342e-4969-4e7c-a063-027ee37e02b8")
-		(property "Reference" "#PWR0122"
-			(at 949.96 365.76 0)
+		(property "Reference" "#PWR122"
+			(at 881.38 416.56 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -91098,7 +101596,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 949.96 364.49 0)
+			(at 881.38 415.29 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -91107,7 +101605,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 949.96 359.41 0)
+			(at 881.38 410.21 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -91116,7 +101614,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 949.96 359.41 0)
+			(at 881.38 410.21 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -91125,7 +101623,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 949.96 359.41 0)
+			(at 881.38 410.21 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -91139,7 +101637,7 @@
 		(instances
 			(project ""
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0122")
+					(reference "#PWR122")
 					(unit 1)
 				)
 			)
@@ -91155,7 +101653,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "b085bee3-85a7-403e-91a6-c1f9d238d20f")
-		(property "Reference" "#PWR0181"
+		(property "Reference" "#PWR181"
 			(at 297.18 219.71 0)
 			(effects
 				(font
@@ -91206,7 +101704,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0181")
+					(reference "#PWR181")
 					(unit 1)
 				)
 			)
@@ -91214,7 +101712,7 @@
 	)
 	(symbol
 		(lib_id "LIB_IRISHSAT:QPL6220QTR7")
-		(at 1075.69 336.55 0)
+		(at 1007.11 387.35 0)
 		(mirror y)
 		(unit 1)
 		(exclude_from_sim no)
@@ -91223,7 +101721,7 @@
 		(dnp no)
 		(uuid "b0b75483-b588-4e92-9f6a-ef5faa2f7dd1")
 		(property "Reference" "IC1"
-			(at 1057.91 328.93 0)
+			(at 989.33 379.73 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -91231,7 +101729,7 @@
 			)
 		)
 		(property "Value" "QPL6220QTR7"
-			(at 1057.91 331.47 0)
+			(at 989.33 382.27 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -91239,7 +101737,7 @@
 			)
 		)
 		(property "Footprint" "LIB_IRISHSAT:SON50P200X200X90-9N-D"
-			(at 1043.94 431.47 0)
+			(at 975.36 482.27 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -91249,7 +101747,7 @@
 			)
 		)
 		(property "Datasheet" "https://www.qorvo.com/products/d/da006481"
-			(at 1043.94 531.47 0)
+			(at 975.36 582.27 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -91259,7 +101757,7 @@
 			)
 		)
 		(property "Description" "RF Amplifier SDARS LNA"
-			(at 1075.69 336.55 0)
+			(at 1007.11 387.35 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -91268,7 +101766,7 @@
 			)
 		)
 		(property "Height" "0.9"
-			(at 1043.94 731.47 0)
+			(at 975.36 782.27 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -91278,7 +101776,7 @@
 			)
 		)
 		(property "Mouser Part Number" "772-QPL6220QTR7"
-			(at 1043.94 831.47 0)
+			(at 975.36 882.27 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -91288,7 +101786,7 @@
 			)
 		)
 		(property "Mouser Price/Stock" "https://www.mouser.co.uk/ProductDetail/Qorvo/QPL6220QTR7?qs=Wj%2FVkw3K%252BMBWkDQlBdTgTw%3D%3D"
-			(at 1043.94 931.47 0)
+			(at 975.36 982.27 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -91298,7 +101796,7 @@
 			)
 		)
 		(property "Manufacturer_Name" "Qorvo"
-			(at 1043.94 1031.47 0)
+			(at 975.36 1082.27 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -91308,7 +101806,7 @@
 			)
 		)
 		(property "Manufacturer_Part_Number" "QPL6220QTR7"
-			(at 1043.94 1131.47 0)
+			(at 975.36 1182.27 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -91561,6 +102059,7 @@
 		)
 	)
 	(symbol
+		(lib_name "XC7A35T-1FTG256C_2")
 		(lib_id "LIB_IRISHSAT:XC7A35T-1FTG256C")
 		(at 228.6 309.88 0)
 		(unit 3)
@@ -91571,7 +102070,7 @@
 		(fields_autoplaced yes)
 		(uuid "b1b52364-37ec-41f1-8d42-d92441ecac65")
 		(property "Reference" "U1"
-			(at 297.18 299.72 0)
+			(at 287.02 299.72 0)
 			(effects
 				(font
 					(size 1.524 1.524)
@@ -91579,7 +102078,7 @@
 			)
 		)
 		(property "Value" "XC7A35T-1FTG256C"
-			(at 297.18 302.26 0)
+			(at 287.02 302.26 0)
 			(effects
 				(font
 					(size 1.524 1.524)
@@ -92402,7 +102901,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "b2214342-8641-4ef0-a551-63ded3ac1b48")
-		(property "Reference" "#PWR0202"
+		(property "Reference" "#PWR202"
 			(at 207.01 741.68 0)
 			(effects
 				(font
@@ -92452,7 +102951,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0202")
+					(reference "#PWR202")
 					(unit 1)
 				)
 			)
@@ -92460,7 +102959,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 435.61 375.92 270)
+		(at 393.7 401.32 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -92468,8 +102967,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "b35946a5-44c9-49cb-9dff-a5a2d75e19a5")
-		(property "Reference" "#PWR0281"
-			(at 429.26 375.92 0)
+		(property "Reference" "#PWR281"
+			(at 387.35 401.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -92478,7 +102977,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 431.8 375.9199 90)
+			(at 389.89 401.3199 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -92488,7 +102987,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 435.61 375.92 0)
+			(at 393.7 401.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -92497,7 +102996,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 435.61 375.92 0)
+			(at 393.7 401.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -92506,7 +103005,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 435.61 375.92 0)
+			(at 393.7 401.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -92520,7 +103019,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0281")
+					(reference "#PWR281")
 					(unit 1)
 				)
 			)
@@ -92594,7 +103093,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 426.72 346.71 90)
+		(at 384.81 372.11 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -92602,8 +103101,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "b4be7fde-1264-41fe-ab39-cae137885d12")
-		(property "Reference" "#PWR0329"
-			(at 433.07 346.71 0)
+		(property "Reference" "#PWR329"
+			(at 391.16 372.11 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -92612,7 +103111,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 430.53 346.7101 90)
+			(at 388.62 372.1101 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -92622,7 +103121,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 426.72 346.71 0)
+			(at 384.81 372.11 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -92631,7 +103130,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 426.72 346.71 0)
+			(at 384.81 372.11 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -92640,7 +103139,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 426.72 346.71 0)
+			(at 384.81 372.11 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -92654,7 +103153,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0329")
+					(reference "#PWR329")
 					(unit 1)
 				)
 			)
@@ -92662,7 +103161,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 593.09 341.63 270)
+		(at 546.1 398.78 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -92670,7 +103169,7 @@
 		(dnp no)
 		(uuid "b4c63d5d-4aba-4731-b14a-c6afb9e028f9")
 		(property "Reference" "C32"
-			(at 593.09 347.218 90)
+			(at 546.1 404.368 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -92678,7 +103177,7 @@
 			)
 		)
 		(property "Value" "10uF"
-			(at 593.09 345.186 90)
+			(at 546.1 402.336 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -92686,7 +103185,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 589.28 342.5952 0)
+			(at 542.29 399.7452 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -92695,7 +103194,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 593.09 341.63 0)
+			(at 546.1 398.78 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -92704,7 +103203,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 593.09 341.63 0)
+			(at 546.1 398.78 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -92729,7 +103228,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 576.58 347.98 180)
+		(at 529.59 405.13 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -92737,7 +103236,7 @@
 		(dnp no)
 		(uuid "b5283e61-cb9c-4d0d-a228-2aaacab18944")
 		(property "Reference" "C38"
-			(at 573.024 348.996 0)
+			(at 526.034 406.146 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -92746,7 +103245,7 @@
 			)
 		)
 		(property "Value" "270pF"
-			(at 573.786 346.964 0)
+			(at 526.796 404.114 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -92755,7 +103254,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 575.6148 344.17 0)
+			(at 528.6248 401.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -92764,7 +103263,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 576.58 347.98 0)
+			(at 529.59 405.13 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -92773,7 +103272,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 576.58 347.98 0)
+			(at 529.59 405.13 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -92806,7 +103305,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "b5a7e3d1-dbdf-4664-b4f6-0996fddf3ae5")
-		(property "Reference" "#PWR074"
+		(property "Reference" "#PWR74"
 			(at 55.88 654.05 0)
 			(effects
 				(font
@@ -92856,7 +103355,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR074")
+					(reference "#PWR74")
 					(unit 1)
 				)
 			)
@@ -92864,7 +103363,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 593.09 328.93 270)
+		(at 546.1 386.08 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -92872,7 +103371,7 @@
 		(dnp no)
 		(uuid "b6101a0a-b130-4130-b60b-7070315ee136")
 		(property "Reference" "C33"
-			(at 593.09 325.374 90)
+			(at 546.1 382.524 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -92880,7 +103379,7 @@
 			)
 		)
 		(property "Value" "10uF"
-			(at 593.09 332.486 90)
+			(at 546.1 389.636 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -92888,7 +103387,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 589.28 329.8952 0)
+			(at 542.29 387.0452 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -92897,7 +103396,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 593.09 328.93 0)
+			(at 546.1 386.08 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -92906,7 +103405,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 593.09 328.93 0)
+			(at 546.1 386.08 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -92939,7 +103438,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "b62a593e-21d8-470b-badb-a8e1d2253cec")
-		(property "Reference" "#PWR064"
+		(property "Reference" "#PWR64"
 			(at 105.41 615.95 0)
 			(effects
 				(font
@@ -92990,7 +103489,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR064")
+					(reference "#PWR64")
 					(unit 1)
 				)
 			)
@@ -93077,7 +103576,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 652.78 280.67 0)
+		(at 725.17 280.67 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -93085,8 +103584,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "b888bfb7-bba0-4bbd-bcbc-bceb7baa66e2")
-		(property "Reference" "#PWR0159"
-			(at 652.78 287.02 0)
+		(property "Reference" "#PWR159"
+			(at 725.17 287.02 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -93095,7 +103594,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 652.78 285.75 0)
+			(at 725.17 285.75 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -93103,7 +103602,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 652.78 280.67 0)
+			(at 725.17 280.67 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -93112,7 +103611,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 652.78 280.67 0)
+			(at 725.17 280.67 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -93121,7 +103620,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 652.78 280.67 0)
+			(at 725.17 280.67 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -93135,7 +103634,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0159")
+					(reference "#PWR159")
 					(unit 1)
 				)
 			)
@@ -93151,7 +103650,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "b90a3b68-3eea-42fb-b119-54444012eb01")
-		(property "Reference" "#PWR066"
+		(property "Reference" "#PWR66"
 			(at 812.8 709.93 0)
 			(effects
 				(font
@@ -93202,13 +103701,14 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR066")
+					(reference "#PWR66")
 					(unit 1)
 				)
 			)
 		)
 	)
 	(symbol
+		(lib_name "TPS62840DLCR_1")
 		(lib_id "LIB_IRISHSAT:TPS62840DLCR")
 		(at 57.15 723.9 0)
 		(unit 1)
@@ -93306,7 +103806,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "b99cab60-47da-42db-9685-283fa11ba869")
-		(property "Reference" "#PWR044"
+		(property "Reference" "#PWR44"
 			(at 222.25 229.87 0)
 			(effects
 				(font
@@ -93357,7 +103857,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR044")
+					(reference "#PWR44")
 					(unit 1)
 				)
 			)
@@ -93645,7 +104145,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "bb458414-f1a7-4413-b097-8c77217c02e4")
-		(property "Reference" "#PWR0183"
+		(property "Reference" "#PWR183"
 			(at 227.33 690.88 0)
 			(effects
 				(font
@@ -93695,7 +104195,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0183")
+					(reference "#PWR183")
 					(unit 1)
 				)
 			)
@@ -93769,7 +104269,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 490.22 367.03 0)
+		(at 448.31 392.43 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -93777,8 +104277,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "bc47dc0b-8900-428b-b610-31e216332a28")
-		(property "Reference" "#PWR0284"
-			(at 490.22 373.38 0)
+		(property "Reference" "#PWR284"
+			(at 448.31 398.78 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -93787,7 +104287,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 490.22 372.11 0)
+			(at 448.31 397.51 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -93796,7 +104296,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 490.22 367.03 0)
+			(at 448.31 392.43 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -93805,7 +104305,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 490.22 367.03 0)
+			(at 448.31 392.43 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -93814,7 +104314,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 490.22 367.03 0)
+			(at 448.31 392.43 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -93828,7 +104328,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0284")
+					(reference "#PWR284")
 					(unit 1)
 				)
 			)
@@ -93911,7 +104411,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "bc8982c6-3ac0-49e4-8bac-75ec88eac091")
-		(property "Reference" "#PWR077"
+		(property "Reference" "#PWR77"
 			(at 63.5 692.15 0)
 			(effects
 				(font
@@ -93961,7 +104461,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR077")
+					(reference "#PWR77")
 					(unit 1)
 				)
 			)
@@ -93977,7 +104477,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "bd0fa170-fbbd-4fd0-8d1b-812bfec69653")
-		(property "Reference" "#PWR0307"
+		(property "Reference" "#PWR307"
 			(at 137.16 55.88 0)
 			(effects
 				(font
@@ -94028,7 +104528,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0307")
+					(reference "#PWR307")
 					(unit 1)
 				)
 			)
@@ -94036,7 +104536,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 593.09 316.23 270)
+		(at 546.1 373.38 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -94044,7 +104544,7 @@
 		(dnp no)
 		(uuid "bd61bea0-0594-4935-b323-fd01ceb34a0a")
 		(property "Reference" "C34"
-			(at 593.09 312.42 90)
+			(at 546.1 369.57 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -94052,7 +104552,7 @@
 			)
 		)
 		(property "Value" "10uF"
-			(at 593.09 319.786 90)
+			(at 546.1 376.936 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -94060,7 +104560,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 589.28 317.1952 0)
+			(at 542.29 374.3452 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -94069,7 +104569,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 593.09 316.23 0)
+			(at 546.1 373.38 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -94078,7 +104578,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 593.09 316.23 0)
+			(at 546.1 373.38 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -94103,7 +104603,7 @@
 	)
 	(symbol
 		(lib_id "power:+3V3")
-		(at 448.31 411.48 90)
+		(at 406.4 436.88 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -94111,7 +104611,7 @@
 		(dnp no)
 		(uuid "bdb71203-ef80-4bc5-a120-5f98f7eff96e")
 		(property "Reference" "#PWR0287"
-			(at 452.12 411.48 0)
+			(at 410.21 436.88 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -94120,7 +104620,7 @@
 			)
 		)
 		(property "Value" "+3V"
-			(at 442.468 411.48 90)
+			(at 400.558 436.88 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -94128,7 +104628,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 448.31 411.48 0)
+			(at 406.4 436.88 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -94137,7 +104637,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 448.31 411.48 0)
+			(at 406.4 436.88 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -94146,7 +104646,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"+3V3\""
-			(at 448.31 411.48 0)
+			(at 406.4 436.88 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -94176,7 +104676,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "be001465-80ae-4568-a217-3b8241880411")
-		(property "Reference" "#PWR012"
+		(property "Reference" "#PWR12"
 			(at 669.29 77.47 0)
 			(effects
 				(font
@@ -94227,7 +104727,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR012")
+					(reference "#PWR12")
 					(unit 1)
 				)
 			)
@@ -94235,7 +104735,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 707.39 325.12 270)
+		(at 637.54 379.73 270)
 		(mirror x)
 		(unit 1)
 		(exclude_from_sim no)
@@ -94244,7 +104744,7 @@
 		(dnp no)
 		(uuid "bfa01020-a1ad-4c8d-bd39-89f6ba1fd3b3")
 		(property "Reference" "R24"
-			(at 709.168 326.898 90)
+			(at 639.318 381.508 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -94252,7 +104752,7 @@
 			)
 		)
 		(property "Value" "1k"
-			(at 705.358 326.898 90)
+			(at 635.508 381.508 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -94260,7 +104760,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 707.136 324.104 90)
+			(at 637.286 378.714 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -94269,7 +104769,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 707.39 325.12 0)
+			(at 637.54 379.73 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -94278,7 +104778,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 707.39 325.12 0)
+			(at 637.54 379.73 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -94370,7 +104870,7 @@
 	)
 	(symbol
 		(lib_id "power:+3V3")
-		(at 434.34 402.59 0)
+		(at 392.43 427.99 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -94378,7 +104878,7 @@
 		(dnp no)
 		(uuid "c087265b-57ca-4e0f-9d31-7651841605d9")
 		(property "Reference" "#PWR0296"
-			(at 434.34 406.4 0)
+			(at 392.43 431.8 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -94387,7 +104887,7 @@
 			)
 		)
 		(property "Value" "+3V"
-			(at 434.34 398.78 0)
+			(at 392.43 424.18 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -94395,7 +104895,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 434.34 402.59 0)
+			(at 392.43 427.99 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -94404,7 +104904,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 434.34 402.59 0)
+			(at 392.43 427.99 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -94413,7 +104913,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"+3V3\""
-			(at 434.34 402.59 0)
+			(at 392.43 427.99 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -94435,7 +104935,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 434.34 407.67 0)
+		(at 392.43 433.07 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -94443,7 +104943,7 @@
 		(dnp no)
 		(uuid "c0bb318c-baf6-4b7d-ac84-8b58f016c492")
 		(property "Reference" "C132"
-			(at 426.212 406.4 0)
+			(at 384.302 431.8 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -94452,7 +104952,7 @@
 			)
 		)
 		(property "Value" "0.1uF"
-			(at 426.212 408.94 0)
+			(at 384.302 434.34 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -94461,7 +104961,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 435.3052 411.48 0)
+			(at 393.3952 436.88 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -94470,7 +104970,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 434.34 407.67 0)
+			(at 392.43 433.07 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -94479,7 +104979,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 434.34 407.67 0)
+			(at 392.43 433.07 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -94504,7 +105004,7 @@
 	)
 	(symbol
 		(lib_id "Device:L")
-		(at 824.23 337.82 270)
+		(at 721.36 337.82 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -94513,7 +105013,7 @@
 		(fields_autoplaced yes)
 		(uuid "c0fc42bd-845a-431e-afee-1dfb83432605")
 		(property "Reference" "L31"
-			(at 824.23 332.74 90)
+			(at 721.36 332.74 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -94521,7 +105021,7 @@
 			)
 		)
 		(property "Value" "2.7nH"
-			(at 824.23 335.28 90)
+			(at 721.36 335.28 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -94529,7 +105029,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 824.23 337.82 0)
+			(at 721.36 337.82 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -94538,7 +105038,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 824.23 337.82 0)
+			(at 721.36 337.82 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -94547,7 +105047,7 @@
 			)
 		)
 		(property "Description" "Inductor"
-			(at 824.23 337.82 0)
+			(at 721.36 337.82 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -94580,7 +105080,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "c1c841b1-be05-42a2-8230-a3f715ff1799")
-		(property "Reference" "#PWR062"
+		(property "Reference" "#PWR62"
 			(at 928.37 666.75 0)
 			(effects
 				(font
@@ -94631,7 +105131,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR062")
+					(reference "#PWR62")
 					(unit 1)
 				)
 			)
@@ -94647,7 +105147,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "c2076364-3aa5-4770-a030-81c829377370")
-		(property "Reference" "#PWR088"
+		(property "Reference" "#PWR88"
 			(at 114.3 666.75 0)
 			(effects
 				(font
@@ -94697,7 +105197,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR088")
+					(reference "#PWR88")
 					(unit 1)
 				)
 			)
@@ -94705,7 +105205,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 707.39 332.74 270)
+		(at 637.54 387.35 270)
 		(mirror x)
 		(unit 1)
 		(exclude_from_sim no)
@@ -94714,7 +105214,7 @@
 		(dnp no)
 		(uuid "c25e451b-31eb-4b43-bafa-59dd2869446e")
 		(property "Reference" "R25"
-			(at 709.168 330.962 90)
+			(at 639.318 385.572 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -94722,7 +105222,7 @@
 			)
 		)
 		(property "Value" "1k"
-			(at 705.358 330.962 90)
+			(at 635.508 385.572 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -94730,7 +105230,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 707.136 331.724 90)
+			(at 637.286 386.334 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -94739,7 +105239,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 707.39 332.74 0)
+			(at 637.54 387.35 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -94748,7 +105248,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 707.39 332.74 0)
+			(at 637.54 387.35 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -94842,7 +105342,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 1080.77 325.12 0)
+		(at 1012.19 375.92 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -94851,7 +105351,7 @@
 		(fields_autoplaced yes)
 		(uuid "c304f6f3-6ed2-4ee6-b2f9-e45d47e451f8")
 		(property "Reference" "R39"
-			(at 1083.31 323.8499 0)
+			(at 1014.73 374.6499 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -94860,7 +105360,7 @@
 			)
 		)
 		(property "Value" "3.32k"
-			(at 1083.31 326.3899 0)
+			(at 1014.73 377.1899 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -94869,7 +105369,7 @@
 			)
 		)
 		(property "Footprint" "Resistor_SMD:R_0402_1005Metric"
-			(at 1081.786 325.374 90)
+			(at 1013.206 376.174 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -94878,7 +105378,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 1080.77 325.12 0)
+			(at 1012.19 375.92 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -94887,7 +105387,7 @@
 			)
 		)
 		(property "Description" "DigiKey: RMC1/16SK3321FTH"
-			(at 1080.77 325.12 0)
+			(at 1012.19 375.92 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -94912,7 +105412,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 1089.66 317.5 90)
+		(at 1021.08 368.3 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -94921,7 +105421,7 @@
 		(fields_autoplaced yes)
 		(uuid "c3f3db72-3447-4cfb-9bda-b3dfb501a5bd")
 		(property "Reference" "C85"
-			(at 1089.66 309.88 90)
+			(at 1021.08 360.68 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -94929,7 +105429,7 @@
 			)
 		)
 		(property "Value" "22pF"
-			(at 1089.66 312.42 90)
+			(at 1021.08 363.22 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -94937,7 +105437,7 @@
 			)
 		)
 		(property "Footprint" "Capacitor_SMD:C_0402_1005Metric"
-			(at 1093.47 316.5348 0)
+			(at 1024.89 367.3348 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -94946,7 +105446,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 1089.66 317.5 0)
+			(at 1021.08 368.3 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -94955,7 +105455,7 @@
 			)
 		)
 		(property "Description" "DigiKey: GJM1555C1H220GB01D"
-			(at 1089.66 317.5 0)
+			(at 1021.08 368.3 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -95392,7 +105892,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 424.18 369.57 270)
+		(at 382.27 394.97 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -95400,8 +105900,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "c66e967a-e2e9-458d-a235-c0817d04b126")
-		(property "Reference" "#PWR0109"
-			(at 417.83 369.57 0)
+		(property "Reference" "#PWR109"
+			(at 375.92 394.97 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -95410,7 +105910,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 420.37 369.5699 90)
+			(at 378.46 394.9699 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -95420,7 +105920,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 424.18 369.57 0)
+			(at 382.27 394.97 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -95429,7 +105929,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 424.18 369.57 0)
+			(at 382.27 394.97 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -95438,7 +105938,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 424.18 369.57 0)
+			(at 382.27 394.97 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -95452,7 +105952,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0109")
+					(reference "#PWR109")
 					(unit 1)
 				)
 			)
@@ -95469,7 +105969,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "c76a0e5b-d1e5-4a17-8609-d5009cab725f")
-		(property "Reference" "#PWR081"
+		(property "Reference" "#PWR81"
 			(at 306.07 648.97 0)
 			(effects
 				(font
@@ -95519,7 +106019,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR081")
+					(reference "#PWR81")
 					(unit 1)
 				)
 			)
@@ -95535,7 +106035,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "c78fc9a4-42ee-45f3-82bb-7e00dd66376e")
-		(property "Reference" "#PWR0223"
+		(property "Reference" "#PWR223"
 			(at 232.41 617.22 0)
 			(effects
 				(font
@@ -95586,7 +106086,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0223")
+					(reference "#PWR223")
 					(unit 1)
 				)
 			)
@@ -95731,7 +106231,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "c913dc9c-13ac-4fab-acf3-322ec0f6429e")
-		(property "Reference" "#PWR0273"
+		(property "Reference" "#PWR273"
 			(at 654.05 129.54 0)
 			(effects
 				(font
@@ -95782,7 +106282,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0273")
+					(reference "#PWR273")
 					(unit 1)
 				)
 			)
@@ -95790,7 +106290,7 @@
 	)
 	(symbol
 		(lib_id "power:+3V3")
-		(at 491.49 374.65 0)
+		(at 449.58 400.05 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -95798,7 +106298,7 @@
 		(dnp no)
 		(uuid "c95ef499-1730-4689-9896-7be6f6564ebe")
 		(property "Reference" "#PWR0285"
-			(at 491.49 378.46 0)
+			(at 449.58 403.86 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -95807,7 +106307,7 @@
 			)
 		)
 		(property "Value" "+3V"
-			(at 494.538 373.888 0)
+			(at 452.628 399.288 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -95815,7 +106315,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 491.49 374.65 0)
+			(at 449.58 400.05 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -95824,7 +106324,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 491.49 374.65 0)
+			(at 449.58 400.05 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -95833,7 +106333,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"+3V3\""
-			(at 491.49 374.65 0)
+			(at 449.58 400.05 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -95855,7 +106355,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 789.94 326.39 0)
+		(at 687.07 326.39 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -95863,8 +106363,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "c98ba545-cbd8-4936-b3c4-d816ef37ed3c")
-		(property "Reference" "#PWR0313"
-			(at 789.94 332.74 0)
+		(property "Reference" "#PWR313"
+			(at 687.07 332.74 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -95873,7 +106373,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 789.94 331.47 0)
+			(at 687.07 331.47 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -95882,7 +106382,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 789.94 326.39 0)
+			(at 687.07 326.39 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -95891,7 +106391,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 789.94 326.39 0)
+			(at 687.07 326.39 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -95900,7 +106400,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 789.94 326.39 0)
+			(at 687.07 326.39 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -95914,7 +106414,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0313")
+					(reference "#PWR313")
 					(unit 1)
 				)
 			)
@@ -95922,7 +106422,7 @@
 	)
 	(symbol
 		(lib_id "power:+5V")
-		(at 651.51 345.44 90)
+		(at 581.66 400.05 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -95931,7 +106431,7 @@
 		(fields_autoplaced yes)
 		(uuid "ca764bfb-1c1f-4e43-a037-1a28720118db")
 		(property "Reference" "#PWR0110"
-			(at 655.32 345.44 0)
+			(at 585.47 400.05 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -95940,7 +106440,7 @@
 			)
 		)
 		(property "Value" "+5V"
-			(at 647.7 345.4399 90)
+			(at 577.85 400.0499 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -95949,7 +106449,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 651.51 345.44 0)
+			(at 581.66 400.05 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -95958,7 +106458,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 651.51 345.44 0)
+			(at 581.66 400.05 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -95967,7 +106467,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"+5V\""
-			(at 651.51 345.44 0)
+			(at 581.66 400.05 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -95997,7 +106497,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "cabcc6a5-00ab-4dda-9359-0f97cc727ed8")
-		(property "Reference" "#PWR087"
+		(property "Reference" "#PWR87"
 			(at 212.09 695.96 0)
 			(effects
 				(font
@@ -96047,7 +106547,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR087")
+					(reference "#PWR87")
 					(unit 1)
 				)
 			)
@@ -96122,7 +106622,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 814.07 351.79 0)
+		(at 711.2 351.79 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -96130,7 +106630,7 @@
 		(dnp no)
 		(uuid "cc9becfb-1ba3-4970-b898-1558fc033371")
 		(property "Reference" "C147"
-			(at 808.736 349.758 0)
+			(at 705.866 349.758 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -96139,7 +106639,7 @@
 			)
 		)
 		(property "Value" "4.7pF"
-			(at 814.07 349.758 0)
+			(at 711.2 349.758 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -96148,7 +106648,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 815.0352 355.6 0)
+			(at 712.1652 355.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -96157,7 +106657,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 814.07 351.79 0)
+			(at 711.2 351.79 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -96166,7 +106666,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 814.07 351.79 0)
+			(at 711.2 351.79 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -96269,7 +106769,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "ccf0d653-abde-4a3e-8f6c-5ccfdb6ae2ab")
-		(property "Reference" "#PWR0146"
+		(property "Reference" "#PWR146"
 			(at 848.36 125.73 0)
 			(effects
 				(font
@@ -96320,7 +106820,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0146")
+					(reference "#PWR146")
 					(unit 1)
 				)
 			)
@@ -96328,7 +106828,7 @@
 	)
 	(symbol
 		(lib_id "power:+3V3")
-		(at 454.66 231.14 90)
+		(at 552.45 265.43 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -96337,7 +106837,7 @@
 		(fields_autoplaced yes)
 		(uuid "ccfed922-ae3f-4dff-81eb-f3e603df2712")
 		(property "Reference" "#PWR0240"
-			(at 458.47 231.14 0)
+			(at 556.26 265.43 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -96346,7 +106846,7 @@
 			)
 		)
 		(property "Value" "+3V3"
-			(at 450.85 231.1399 90)
+			(at 548.64 265.4299 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -96355,7 +106855,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 454.66 231.14 0)
+			(at 552.45 265.43 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -96364,7 +106864,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 454.66 231.14 0)
+			(at 552.45 265.43 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -96373,7 +106873,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"+3V3\""
-			(at 454.66 231.14 0)
+			(at 552.45 265.43 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -96395,7 +106895,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 547.37 403.86 0)
+		(at 666.75 392.43 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -96403,7 +106903,7 @@
 		(dnp no)
 		(uuid "cd054616-e61b-4dd3-995c-25a5b5658da6")
 		(property "Reference" "C46"
-			(at 541.02 402.082 0)
+			(at 660.4 390.652 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -96412,7 +106912,7 @@
 			)
 		)
 		(property "Value" ".1uF"
-			(at 540.512 403.86 0)
+			(at 659.892 392.43 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -96421,7 +106921,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 548.3352 407.67 0)
+			(at 667.7152 396.24 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -96430,7 +106930,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 547.37 403.86 0)
+			(at 666.75 392.43 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -96439,7 +106939,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 547.37 403.86 0)
+			(at 666.75 392.43 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -96539,7 +107039,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "cd6a6374-bd7a-492d-8151-8460fcfa3822")
-		(property "Reference" "#PWR0346"
+		(property "Reference" "#PWR346"
 			(at 200.66 342.9 0)
 			(effects
 				(font
@@ -96590,7 +107090,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0346")
+					(reference "#PWR346")
 					(unit 1)
 				)
 			)
@@ -96673,7 +107173,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "cdd5b2b5-fa7e-4b40-8857-28bbd28ad227")
-		(property "Reference" "#PWR022"
+		(property "Reference" "#PWR22"
 			(at 975.36 146.05 0)
 			(effects
 				(font
@@ -96723,7 +107223,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR022")
+					(reference "#PWR22")
 					(unit 1)
 				)
 			)
@@ -96731,7 +107231,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 421.64 341.63 90)
+		(at 379.73 367.03 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -96739,7 +107239,7 @@
 		(dnp no)
 		(uuid "ce25b4a6-be0d-49ae-ba25-4addb06d09e5")
 		(property "Reference" "C154"
-			(at 419.608 338.074 90)
+			(at 377.698 363.474 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -96748,7 +107248,7 @@
 			)
 		)
 		(property "Value" ".1uF"
-			(at 419.862 345.186 90)
+			(at 377.952 370.586 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -96757,7 +107257,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 425.45 340.6648 0)
+			(at 383.54 366.0648 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -96766,7 +107266,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 421.64 341.63 0)
+			(at 379.73 367.03 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -96775,7 +107275,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 421.64 341.63 0)
+			(at 379.73 367.03 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -96800,7 +107300,7 @@
 	)
 	(symbol
 		(lib_id "Device:L")
-		(at 582.93 328.93 270)
+		(at 535.94 386.08 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -96808,7 +107308,7 @@
 		(dnp no)
 		(uuid "ce460e65-5eb5-4049-8259-a08b127a3b3b")
 		(property "Reference" "L7"
-			(at 582.93 327.406 90)
+			(at 535.94 384.556 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -96816,7 +107316,7 @@
 			)
 		)
 		(property "Value" "27uH"
-			(at 582.93 331.47 90)
+			(at 535.94 388.62 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -96824,7 +107324,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 582.93 328.93 0)
+			(at 535.94 386.08 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -96833,7 +107333,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 582.93 328.93 0)
+			(at 535.94 386.08 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -96842,7 +107342,7 @@
 			)
 		)
 		(property "Description" "Inductor"
-			(at 582.93 328.93 0)
+			(at 535.94 386.08 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -96866,6 +107366,7 @@
 		)
 	)
 	(symbol
+		(lib_name "W25Q32JVSSIQ_1")
 		(lib_id "LIB_IRISHSAT:W25Q32JVSSIQ")
 		(at 81.28 132.08 0)
 		(unit 1)
@@ -96963,7 +107464,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "ce94369a-6607-457b-85b7-2d14f735a5bc")
-		(property "Reference" "#PWR0341"
+		(property "Reference" "#PWR341"
 			(at 222.25 265.43 0)
 			(effects
 				(font
@@ -97014,7 +107515,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0341")
+					(reference "#PWR341")
 					(unit 1)
 				)
 			)
@@ -97089,7 +107590,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 452.12 335.28 180)
+		(at 410.21 360.68 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -97097,8 +107598,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "cf0a40f2-31e6-4696-8577-7c58e4db0073")
-		(property "Reference" "#PWR048"
-			(at 452.12 328.93 0)
+		(property "Reference" "#PWR48"
+			(at 410.21 354.33 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -97107,7 +107608,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 452.12 330.2 0)
+			(at 410.21 355.6 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -97116,7 +107617,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 452.12 335.28 0)
+			(at 410.21 360.68 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -97125,7 +107626,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 452.12 335.28 0)
+			(at 410.21 360.68 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -97134,7 +107635,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 452.12 335.28 0)
+			(at 410.21 360.68 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -97148,7 +107649,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR048")
+					(reference "#PWR48")
 					(unit 1)
 				)
 			)
@@ -97226,7 +107727,7 @@
 	)
 	(symbol
 		(lib_id "power:+5V")
-		(at 558.8 386.08 0)
+		(at 678.18 374.65 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -97234,7 +107735,7 @@
 		(dnp no)
 		(uuid "cf20c754-668d-49d7-b3db-baa6e3df27bc")
 		(property "Reference" "#PWR0125"
-			(at 558.8 389.89 0)
+			(at 678.18 378.46 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -97243,7 +107744,7 @@
 			)
 		)
 		(property "Value" "+5V"
-			(at 558.8 382.27 0)
+			(at 678.18 370.84 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -97251,7 +107752,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 558.8 386.08 0)
+			(at 678.18 374.65 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -97260,7 +107761,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 558.8 386.08 0)
+			(at 678.18 374.65 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -97269,7 +107770,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"+5V\""
-			(at 558.8 386.08 0)
+			(at 678.18 374.65 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -97299,7 +107800,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "cf60bf34-d94b-4736-bd0d-9c1db1a588e9")
-		(property "Reference" "#PWR063"
+		(property "Reference" "#PWR63"
 			(at 105.41 613.41 0)
 			(effects
 				(font
@@ -97350,7 +107851,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR063")
+					(reference "#PWR63")
 					(unit 1)
 				)
 			)
@@ -97572,7 +108073,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 659.13 248.92 90)
+		(at 731.52 248.92 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -97580,8 +108081,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "d019ef21-d650-4365-8de6-30b836bf1203")
-		(property "Reference" "#PWR0120"
-			(at 665.48 248.92 0)
+		(property "Reference" "#PWR120"
+			(at 737.87 248.92 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -97590,7 +108091,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 662.94 248.9199 90)
+			(at 735.33 248.9199 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -97599,7 +108100,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 659.13 248.92 0)
+			(at 731.52 248.92 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -97608,7 +108109,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 659.13 248.92 0)
+			(at 731.52 248.92 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -97617,7 +108118,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 659.13 248.92 0)
+			(at 731.52 248.92 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -97631,7 +108132,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0120")
+					(reference "#PWR120")
 					(unit 1)
 				)
 			)
@@ -97647,7 +108148,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "d138dbf0-e375-4ec5-8d8f-24a46d27f099")
-		(property "Reference" "#PWR0154"
+		(property "Reference" "#PWR154"
 			(at 610.87 76.2 0)
 			(effects
 				(font
@@ -97698,7 +108199,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0154")
+					(reference "#PWR154")
 					(unit 1)
 				)
 			)
@@ -97706,7 +108207,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 511.81 378.46 0)
+		(at 469.9 403.86 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -97714,8 +108215,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "d16c7663-98a5-45aa-957d-294f7a4d139f")
-		(property "Reference" "#PWR0294"
-			(at 511.81 384.81 0)
+		(property "Reference" "#PWR294"
+			(at 469.9 410.21 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -97724,7 +108225,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 511.81 383.54 0)
+			(at 469.9 408.94 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -97733,7 +108234,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 511.81 378.46 0)
+			(at 469.9 403.86 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -97742,7 +108243,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 511.81 378.46 0)
+			(at 469.9 403.86 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -97751,7 +108252,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 511.81 378.46 0)
+			(at 469.9 403.86 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -97765,7 +108266,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0294")
+					(reference "#PWR294")
 					(unit 1)
 				)
 			)
@@ -97773,7 +108274,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 1132.84 341.63 90)
+		(at 1064.26 392.43 90)
 		(mirror x)
 		(unit 1)
 		(exclude_from_sim no)
@@ -97782,8 +108283,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "d19378c8-1500-4dfe-97fd-fcc580a6336d")
-		(property "Reference" "#PWR028"
-			(at 1139.19 341.63 0)
+		(property "Reference" "#PWR28"
+			(at 1070.61 392.43 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -97792,7 +108293,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 1136.65 341.6299 90)
+			(at 1068.07 392.4299 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -97801,7 +108302,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 1132.84 341.63 0)
+			(at 1064.26 392.43 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -97810,7 +108311,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 1132.84 341.63 0)
+			(at 1064.26 392.43 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -97819,7 +108320,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 1132.84 341.63 0)
+			(at 1064.26 392.43 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -97833,7 +108334,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR028")
+					(reference "#PWR28")
 					(unit 1)
 				)
 			)
@@ -97841,7 +108342,7 @@
 	)
 	(symbol
 		(lib_id "Device:L")
-		(at 803.91 347.98 270)
+		(at 701.04 347.98 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -97849,7 +108350,7 @@
 		(dnp no)
 		(uuid "d1b8ce55-1235-4a1b-ba61-c1234e7e1a45")
 		(property "Reference" "L30"
-			(at 803.91 340.36 90)
+			(at 701.04 340.36 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -97857,7 +108358,7 @@
 			)
 		)
 		(property "Value" "2.7nH"
-			(at 803.91 342.9 90)
+			(at 701.04 342.9 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -97865,7 +108366,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 803.91 347.98 0)
+			(at 701.04 347.98 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -97874,7 +108375,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 803.91 347.98 0)
+			(at 701.04 347.98 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -97883,7 +108384,7 @@
 			)
 		)
 		(property "Description" "Inductor"
-			(at 803.91 347.98 0)
+			(at 701.04 347.98 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -97916,7 +108417,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "d1c6960c-7b79-41dc-8d13-4513c2145aaf")
-		(property "Reference" "#PWR0166"
+		(property "Reference" "#PWR166"
 			(at 200.66 345.44 0)
 			(effects
 				(font
@@ -97967,7 +108468,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0166")
+					(reference "#PWR166")
 					(unit 1)
 				)
 			)
@@ -98045,7 +108546,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 802.64 320.04 0)
+		(at 699.77 320.04 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -98053,8 +108554,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "d1ea0e70-f158-4416-b1b6-ea0107c3c20e")
-		(property "Reference" "#PWR0316"
-			(at 802.64 326.39 0)
+		(property "Reference" "#PWR316"
+			(at 699.77 326.39 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -98063,7 +108564,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 802.64 325.12 0)
+			(at 699.77 325.12 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -98072,7 +108573,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 802.64 320.04 0)
+			(at 699.77 320.04 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -98081,7 +108582,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 802.64 320.04 0)
+			(at 699.77 320.04 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -98090,7 +108591,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 802.64 320.04 0)
+			(at 699.77 320.04 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -98104,7 +108605,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0316")
+					(reference "#PWR316")
 					(unit 1)
 				)
 			)
@@ -98317,7 +108818,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 916.94 331.47 90)
+		(at 848.36 382.27 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -98325,7 +108826,7 @@
 		(dnp no)
 		(uuid "d3c0400d-4d99-4f6f-8027-6c914c4e1126")
 		(property "Reference" "C54"
-			(at 914.908 327.914 90)
+			(at 846.328 378.714 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -98334,7 +108835,7 @@
 			)
 		)
 		(property "Value" "1000pF"
-			(at 913.638 335.026 90)
+			(at 845.058 385.826 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -98343,7 +108844,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 920.75 330.5048 0)
+			(at 852.17 381.3048 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -98352,7 +108853,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 916.94 331.47 0)
+			(at 848.36 382.27 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -98361,7 +108862,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 916.94 331.47 0)
+			(at 848.36 382.27 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -98521,7 +109022,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 541.02 347.98 180)
+		(at 494.03 405.13 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -98529,7 +109030,7 @@
 		(dnp no)
 		(uuid "d4d8ce07-ffc2-4aeb-91b7-ed1434b9011a")
 		(property "Reference" "R11"
-			(at 538.734 348.996 0)
+			(at 491.744 406.146 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -98538,7 +109039,7 @@
 			)
 		)
 		(property "Value" "500"
-			(at 538.734 346.964 0)
+			(at 491.744 404.114 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -98547,7 +109048,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 540.004 347.726 90)
+			(at 493.014 404.876 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -98556,7 +109057,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 541.02 347.98 0)
+			(at 494.03 405.13 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -98565,7 +109066,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 541.02 347.98 0)
+			(at 494.03 405.13 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -98666,7 +109167,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "d55218d0-429e-4ff7-9358-8bbb8557ed5b")
-		(property "Reference" "#PWR0336"
+		(property "Reference" "#PWR336"
 			(at 137.16 330.2 0)
 			(effects
 				(font
@@ -98716,7 +109217,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0336")
+					(reference "#PWR336")
 					(unit 1)
 				)
 			)
@@ -98724,7 +109225,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 551.18 196.85 0)
+		(at 609.6 214.63 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -98733,7 +109234,7 @@
 		(fields_autoplaced yes)
 		(uuid "d651f256-1869-4dd3-abf4-4e6fc39df908")
 		(property "Reference" "C139"
-			(at 554.99 195.5799 0)
+			(at 613.41 213.3599 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -98742,7 +109243,7 @@
 			)
 		)
 		(property "Value" "39nF"
-			(at 554.99 198.1199 0)
+			(at 613.41 215.8999 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -98751,7 +109252,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 552.1452 200.66 0)
+			(at 610.5652 218.44 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -98760,7 +109261,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 551.18 196.85 0)
+			(at 609.6 214.63 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -98769,7 +109270,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 551.18 196.85 0)
+			(at 609.6 214.63 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -99066,7 +109567,7 @@
 	)
 	(symbol
 		(lib_id "power:+3.3V")
-		(at 643.89 168.91 0)
+		(at 716.28 168.91 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -99074,7 +109575,7 @@
 		(dnp no)
 		(uuid "d91198b4-f291-423c-a016-5eb8a017dcdb")
 		(property "Reference" "#PWR0116"
-			(at 643.89 172.72 0)
+			(at 716.28 172.72 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -99083,7 +109584,7 @@
 			)
 		)
 		(property "Value" "+3.3V"
-			(at 645.16 164.338 0)
+			(at 717.55 164.338 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -99091,7 +109592,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 643.89 168.91 0)
+			(at 716.28 168.91 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -99100,7 +109601,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 643.89 168.91 0)
+			(at 716.28 168.91 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -99109,7 +109610,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"+3.3V\""
-			(at 643.89 168.91 0)
+			(at 716.28 168.91 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -99200,7 +109701,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 480.06 373.38 90)
+		(at 438.15 398.78 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -99208,8 +109709,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "d9dc76c5-0dff-4d76-9c53-7ea83e4e2e3e")
-		(property "Reference" "#PWR051"
-			(at 486.41 373.38 0)
+		(property "Reference" "#PWR51"
+			(at 444.5 398.78 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -99218,7 +109719,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 483.87 373.3799 90)
+			(at 441.96 398.7799 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -99228,7 +109729,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 480.06 373.38 0)
+			(at 438.15 398.78 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -99237,7 +109738,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 480.06 373.38 0)
+			(at 438.15 398.78 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -99246,7 +109747,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 480.06 373.38 0)
+			(at 438.15 398.78 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -99260,7 +109761,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR051")
+					(reference "#PWR51")
 					(unit 1)
 				)
 			)
@@ -99268,7 +109769,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 712.47 351.79 180)
+		(at 642.62 406.4 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -99276,7 +109777,7 @@
 		(dnp no)
 		(uuid "da3e81f2-5139-460f-8e9d-27fbde57396f")
 		(property "Reference" "C35"
-			(at 716.28 350.5199 0)
+			(at 646.43 405.1299 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -99285,7 +109786,7 @@
 			)
 		)
 		(property "Value" "100nF"
-			(at 716.28 353.0599 0)
+			(at 646.43 407.6699 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -99294,7 +109795,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 711.5048 347.98 0)
+			(at 641.6548 402.59 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -99303,7 +109804,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 712.47 351.79 0)
+			(at 642.62 406.4 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -99312,7 +109813,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 712.47 351.79 0)
+			(at 642.62 406.4 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -99345,7 +109846,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "dab2042f-3692-4577-a8cd-0b3c74ba3c87")
-		(property "Reference" "#PWR0328"
+		(property "Reference" "#PWR328"
 			(at 441.96 80.01 0)
 			(effects
 				(font
@@ -99396,7 +109897,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0328")
+					(reference "#PWR328")
 					(unit 1)
 				)
 			)
@@ -99479,7 +109980,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "db0919c3-c9d6-4684-ad3a-44b3e0d7241b")
-		(property "Reference" "#PWR04"
+		(property "Reference" "#PWR4"
 			(at 669.29 54.61 0)
 			(effects
 				(font
@@ -99530,7 +110031,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR04")
+					(reference "#PWR4")
 					(unit 1)
 				)
 			)
@@ -99538,7 +110039,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 651.51 330.2 270)
+		(at 581.66 384.81 270)
 		(mirror x)
 		(unit 1)
 		(exclude_from_sim no)
@@ -99547,8 +110048,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "db805aa0-f926-4374-974a-49e71c7b88eb")
-		(property "Reference" "#PWR0135"
-			(at 645.16 330.2 0)
+		(property "Reference" "#PWR135"
+			(at 575.31 384.81 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -99557,7 +110058,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 647.7 330.1999 90)
+			(at 577.85 384.8099 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -99567,7 +110068,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 651.51 330.2 0)
+			(at 581.66 384.81 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -99576,7 +110077,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 651.51 330.2 0)
+			(at 581.66 384.81 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -99585,7 +110086,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 651.51 330.2 0)
+			(at 581.66 384.81 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -99599,7 +110100,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0135")
+					(reference "#PWR135")
 					(unit 1)
 				)
 			)
@@ -99607,7 +110108,7 @@
 	)
 	(symbol
 		(lib_id "Device:L")
-		(at 582.93 316.23 270)
+		(at 535.94 373.38 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -99615,7 +110116,7 @@
 		(dnp no)
 		(uuid "dbd8c8af-a19f-4456-bb99-6ceaf0c2981c")
 		(property "Reference" "L4"
-			(at 582.93 312.42 90)
+			(at 535.94 369.57 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -99623,7 +110124,7 @@
 			)
 		)
 		(property "Value" "27uH"
-			(at 582.93 314.452 90)
+			(at 535.94 371.602 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -99631,7 +110132,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 582.93 316.23 0)
+			(at 535.94 373.38 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -99640,7 +110141,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 582.93 316.23 0)
+			(at 535.94 373.38 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -99649,7 +110150,7 @@
 			)
 		)
 		(property "Description" "Inductor"
-			(at 582.93 316.23 0)
+			(at 535.94 373.38 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -99674,7 +110175,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 436.88 344.17 0)
+		(at 394.97 369.57 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -99682,8 +110183,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "dc1a4458-f363-40cc-995e-7405e01f85e9")
-		(property "Reference" "#PWR0292"
-			(at 436.88 350.52 0)
+		(property "Reference" "#PWR292"
+			(at 394.97 375.92 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -99692,7 +110193,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 436.88 349.25 0)
+			(at 394.97 374.65 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -99701,7 +110202,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 436.88 344.17 0)
+			(at 394.97 369.57 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -99710,7 +110211,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 436.88 344.17 0)
+			(at 394.97 369.57 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -99719,7 +110220,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 436.88 344.17 0)
+			(at 394.97 369.57 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -99733,7 +110234,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0292")
+					(reference "#PWR292")
 					(unit 1)
 				)
 			)
@@ -99947,7 +110448,7 @@
 	)
 	(symbol
 		(lib_id "power:+3V3")
-		(at 416.56 372.11 0)
+		(at 374.65 397.51 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -99955,7 +110456,7 @@
 		(dnp no)
 		(uuid "e16ebdca-cdaf-4a63-844b-e746fd455dfa")
 		(property "Reference" "#PWR0289"
-			(at 416.56 375.92 0)
+			(at 374.65 401.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -99964,7 +110465,7 @@
 			)
 		)
 		(property "Value" "+3V"
-			(at 416.56 368.3 0)
+			(at 374.65 393.7 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -99972,7 +110473,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 416.56 372.11 0)
+			(at 374.65 397.51 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -99981,7 +110482,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 416.56 372.11 0)
+			(at 374.65 397.51 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -99990,7 +110491,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"+3V3\""
-			(at 416.56 372.11 0)
+			(at 374.65 397.51 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -100079,7 +110580,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 636.27 274.32 0)
+		(at 708.66 274.32 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -100087,8 +110588,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "e1a15a6c-35e4-4b34-bab8-d839ec7b7cd2")
-		(property "Reference" "#PWR0119"
-			(at 636.27 280.67 0)
+		(property "Reference" "#PWR119"
+			(at 708.66 280.67 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -100097,7 +110598,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 636.27 279.4 0)
+			(at 708.66 279.4 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -100105,7 +110606,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 636.27 274.32 0)
+			(at 708.66 274.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -100114,7 +110615,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 636.27 274.32 0)
+			(at 708.66 274.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -100123,7 +110624,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 636.27 274.32 0)
+			(at 708.66 274.32 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -100137,7 +110638,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0119")
+					(reference "#PWR119")
 					(unit 1)
 				)
 			)
@@ -100145,7 +110646,7 @@
 	)
 	(symbol
 		(lib_id "Device:L")
-		(at 557.53 341.63 270)
+		(at 510.54 398.78 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -100153,7 +110654,7 @@
 		(dnp no)
 		(uuid "e1d93d59-852f-41a3-ac5d-b3990e9a9ae4")
 		(property "Reference" "L15"
-			(at 557.53 343.916 90)
+			(at 510.54 401.066 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -100161,7 +110662,7 @@
 			)
 		)
 		(property "Value" "10uH"
-			(at 557.53 339.852 90)
+			(at 510.54 397.002 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -100169,7 +110670,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 557.53 341.63 0)
+			(at 510.54 398.78 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -100178,7 +110679,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 557.53 341.63 0)
+			(at 510.54 398.78 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -100187,7 +110688,7 @@
 			)
 		)
 		(property "Description" "Inductor"
-			(at 557.53 341.63 0)
+			(at 510.54 398.78 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -100220,7 +110721,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "e2171b5b-199e-43b9-a75b-63ef77bfbc5a")
-		(property "Reference" "#PWR06"
+		(property "Reference" "#PWR6"
 			(at 669.29 59.69 0)
 			(effects
 				(font
@@ -100271,7 +110772,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR06")
+					(reference "#PWR6")
 					(unit 1)
 				)
 			)
@@ -100354,7 +110855,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "e322fbd2-ae80-43e6-b3ae-5dbb7c6047f9")
-		(property "Reference" "#PWR057"
+		(property "Reference" "#PWR57"
 			(at 967.74 694.69 0)
 			(effects
 				(font
@@ -100405,7 +110906,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR057")
+					(reference "#PWR57")
 					(unit 1)
 				)
 			)
@@ -100421,7 +110922,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "e3b1213c-9f83-4069-81f4-6e4a4c6ed75f")
-		(property "Reference" "#PWR014"
+		(property "Reference" "#PWR14"
 			(at 669.29 82.55 0)
 			(effects
 				(font
@@ -100472,7 +110973,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR014")
+					(reference "#PWR14")
 					(unit 1)
 				)
 			)
@@ -100480,7 +110981,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 707.39 340.36 270)
+		(at 637.54 394.97 270)
 		(mirror x)
 		(unit 1)
 		(exclude_from_sim no)
@@ -100489,7 +110990,7 @@
 		(dnp no)
 		(uuid "e43407bc-5c4d-40e8-8b6e-2aeba8e0420b")
 		(property "Reference" "R26"
-			(at 710.438 342.138 90)
+			(at 640.588 396.748 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -100497,7 +110998,7 @@
 			)
 		)
 		(property "Value" "1k"
-			(at 704.85 342.138 90)
+			(at 635 396.748 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -100505,7 +111006,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 707.136 339.344 90)
+			(at 637.286 393.954 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -100514,7 +111015,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 707.39 340.36 0)
+			(at 637.54 394.97 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -100523,7 +111024,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 707.39 340.36 0)
+			(at 637.54 394.97 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -100625,7 +111126,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "e53c8970-d3c5-4ec7-84a0-a8db435e8a81")
-		(property "Reference" "#PWR09"
+		(property "Reference" "#PWR9"
 			(at 669.29 67.31 0)
 			(effects
 				(font
@@ -100676,7 +111177,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR09")
+					(reference "#PWR9")
 					(unit 1)
 				)
 			)
@@ -100754,7 +111255,7 @@
 	)
 	(symbol
 		(lib_id "LIB_IRISHSAT:RFPC-SMA27-F")
-		(at 1165.86 337.82 0)
+		(at 1097.28 388.62 0)
 		(mirror y)
 		(unit 1)
 		(exclude_from_sim no)
@@ -100763,7 +111264,7 @@
 		(dnp no)
 		(uuid "e6e41a86-0fa4-4deb-8cf6-c6f0214e9316")
 		(property "Reference" "J3"
-			(at 1162.3929 331.47 0)
+			(at 1093.8129 382.27 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -100771,7 +111272,7 @@
 			)
 		)
 		(property "Value" "RFPC-SMA27-F"
-			(at 1162.3929 334.01 0)
+			(at 1093.8129 384.81 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -100779,7 +111280,7 @@
 			)
 		)
 		(property "Footprint" "LIB_IRISHSAT:GRADCONN_RFPC-SMA27-F"
-			(at 1165.86 337.82 0)
+			(at 1097.28 388.62 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -100789,7 +111290,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 1165.86 337.82 0)
+			(at 1097.28 388.62 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -100798,7 +111299,7 @@
 			)
 		)
 		(property "Description" ""
-			(at 1165.86 337.82 0)
+			(at 1097.28 388.62 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -100807,7 +111308,7 @@
 			)
 		)
 		(property "PARTREV" "1.0"
-			(at 1165.86 337.82 0)
+			(at 1097.28 388.62 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -100817,7 +111318,7 @@
 			)
 		)
 		(property "MANUFACTURER" "GradConn"
-			(at 1165.86 337.82 0)
+			(at 1097.28 388.62 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -100827,7 +111328,7 @@
 			)
 		)
 		(property "MAXIMUM_PACKAGE_HEIGHT" "10.3mm"
-			(at 1165.86 337.82 0)
+			(at 1097.28 388.62 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -100837,7 +111338,7 @@
 			)
 		)
 		(property "STANDARD" "Manufacturer Recommendations"
-			(at 1165.86 337.82 0)
+			(at 1097.28 388.62 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -100872,7 +111373,7 @@
 	)
 	(symbol
 		(lib_id "Device:R_US")
-		(at 666.75 238.76 90)
+		(at 739.14 238.76 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -100881,7 +111382,7 @@
 		(fields_autoplaced yes)
 		(uuid "e6eef96d-b330-4dec-a06e-800739393ce6")
 		(property "Reference" "R55"
-			(at 666.75 232.41 90)
+			(at 739.14 232.41 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -100889,7 +111390,7 @@
 			)
 		)
 		(property "Value" "5.1k"
-			(at 666.75 234.95 90)
+			(at 739.14 234.95 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -100897,7 +111398,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 667.004 237.744 90)
+			(at 739.394 237.744 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -100906,7 +111407,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 666.75 238.76 0)
+			(at 739.14 238.76 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -100915,7 +111416,7 @@
 			)
 		)
 		(property "Description" "Resistor, US symbol"
-			(at 666.75 238.76 0)
+			(at 739.14 238.76 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -100940,7 +111441,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 623.57 251.46 0)
+		(at 695.96 251.46 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -100948,8 +111449,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "e750ef3f-5d18-4689-8fb0-f786c4d686d0")
-		(property "Reference" "#PWR015"
-			(at 623.57 257.81 0)
+		(property "Reference" "#PWR15"
+			(at 695.96 257.81 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -100958,7 +111459,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 623.57 256.54 0)
+			(at 695.96 256.54 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -100966,7 +111467,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 623.57 251.46 0)
+			(at 695.96 251.46 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -100975,7 +111476,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 623.57 251.46 0)
+			(at 695.96 251.46 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -100984,7 +111485,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 623.57 251.46 0)
+			(at 695.96 251.46 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -100998,7 +111499,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR015")
+					(reference "#PWR15")
 					(unit 1)
 				)
 			)
@@ -101124,7 +111625,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 562.61 200.66 0)
+		(at 621.03 218.44 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -101133,7 +111634,7 @@
 		(fields_autoplaced yes)
 		(uuid "e7b790d9-f682-4b40-856c-776485a23cdf")
 		(property "Reference" "C140"
-			(at 566.42 199.3899 0)
+			(at 624.84 217.1699 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -101142,7 +111643,7 @@
 			)
 		)
 		(property "Value" "1200pF"
-			(at 566.42 201.9299 0)
+			(at 624.84 219.7099 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -101151,7 +111652,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 563.5752 204.47 0)
+			(at 621.9952 222.25 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -101160,7 +111661,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 562.61 200.66 0)
+			(at 621.03 218.44 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -101169,7 +111670,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 562.61 200.66 0)
+			(at 621.03 218.44 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -101263,7 +111764,7 @@
 	)
 	(symbol
 		(lib_id "LIB_IRISHSAT:B39921B2672P810")
-		(at 1021.08 339.09 0)
+		(at 952.5 389.89 0)
 		(mirror y)
 		(unit 1)
 		(exclude_from_sim no)
@@ -101272,7 +111773,7 @@
 		(dnp no)
 		(uuid "e7f6b348-9b74-4a5b-884b-197c93fdd3e5")
 		(property "Reference" "FL2"
-			(at 1002.03 331.47 0)
+			(at 933.45 382.27 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -101280,7 +111781,7 @@
 			)
 		)
 		(property "Value" "B39921B2672P810"
-			(at 1002.03 334.01 0)
+			(at 933.45 384.81 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -101288,7 +111789,7 @@
 			)
 		)
 		(property "Footprint" "LIB_IRISHSAT:B39921B2672P810"
-			(at 986.79 434.01 0)
+			(at 918.21 484.81 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -101298,7 +111799,7 @@
 			)
 		)
 		(property "Datasheet" "https://componentsearchengine.com/Datasheets/1/B39921B2672P810.pdf"
-			(at 986.79 534.01 0)
+			(at 918.21 584.81 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -101308,7 +111809,7 @@
 			)
 		)
 		(property "Description" "Signal Conditioning 50ohm 26MHz CSSP3 GT"
-			(at 1021.08 339.09 0)
+			(at 952.5 389.89 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -101317,7 +111818,7 @@
 			)
 		)
 		(property "Height" "0.45"
-			(at 986.79 734.01 0)
+			(at 918.21 784.81 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -101327,7 +111828,7 @@
 			)
 		)
 		(property "Mouser Part Number" "871-B39921B2672P810"
-			(at 986.79 834.01 0)
+			(at 918.21 884.81 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -101337,7 +111838,7 @@
 			)
 		)
 		(property "Mouser Price/Stock" "https://www.mouser.co.uk/ProductDetail/RF360/B39921B2672P810?qs=bZr6mbWTK5kdVCepanD%252BhQ%3D%3D"
-			(at 986.79 934.01 0)
+			(at 918.21 984.81 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -101347,7 +111848,7 @@
 			)
 		)
 		(property "Manufacturer_Name" "RF360"
-			(at 986.79 1034.01 0)
+			(at 918.21 1084.81 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -101357,7 +111858,7 @@
 			)
 		)
 		(property "Manufacturer_Part_Number" "B39921B2672P810"
-			(at 986.79 1134.01 0)
+			(at 918.21 1184.81 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -101400,7 +111901,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "e845fb2a-6dc9-441a-aa4d-4a7bea354ba0")
-		(property "Reference" "#PWR0179"
+		(property "Reference" "#PWR179"
 			(at 297.18 273.05 0)
 			(effects
 				(font
@@ -101451,7 +111952,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0179")
+					(reference "#PWR179")
 					(unit 1)
 				)
 			)
@@ -101537,7 +112038,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "e9202762-a8a5-47ca-9922-249c4aa77369")
-		(property "Reference" "#PWR065"
+		(property "Reference" "#PWR65"
 			(at 812.8 715.01 0)
 			(effects
 				(font
@@ -101588,7 +112089,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR065")
+					(reference "#PWR65")
 					(unit 1)
 				)
 			)
@@ -101811,7 +112312,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "ea7e8568-cb94-487e-921f-cce66f08a860")
-		(property "Reference" "#PWR0277"
+		(property "Reference" "#PWR277"
 			(at 633.73 167.64 0)
 			(effects
 				(font
@@ -101862,7 +112363,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0277")
+					(reference "#PWR277")
 					(unit 1)
 				)
 			)
@@ -101878,7 +112379,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "ea8b48b4-6415-4367-9b6e-f357f85542b3")
-		(property "Reference" "#PWR0234"
+		(property "Reference" "#PWR234"
 			(at 222.25 640.08 0)
 			(effects
 				(font
@@ -101929,7 +112430,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0234")
+					(reference "#PWR234")
 					(unit 1)
 				)
 			)
@@ -101937,7 +112438,7 @@
 	)
 	(symbol
 		(lib_id "Device:L")
-		(at 824.23 347.98 270)
+		(at 721.36 347.98 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -101945,7 +112446,7 @@
 		(dnp no)
 		(uuid "ea9955b4-d6cf-45da-85df-46ecd18f5dd3")
 		(property "Reference" "L32"
-			(at 824.23 340.36 90)
+			(at 721.36 340.36 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -101953,7 +112454,7 @@
 			)
 		)
 		(property "Value" "2.7nH"
-			(at 824.23 342.9 90)
+			(at 721.36 342.9 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -101961,7 +112462,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 824.23 347.98 0)
+			(at 721.36 347.98 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -101970,7 +112471,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 824.23 347.98 0)
+			(at 721.36 347.98 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -101979,7 +112480,7 @@
 			)
 		)
 		(property "Description" "Inductor"
-			(at 824.23 347.98 0)
+			(at 721.36 347.98 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -102004,7 +112505,7 @@
 	)
 	(symbol
 		(lib_id "power:+3V3")
-		(at 436.88 335.28 0)
+		(at 394.97 360.68 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -102012,7 +112513,7 @@
 		(dnp no)
 		(uuid "eacce5df-449b-4d30-9c64-e62f885c1e7a")
 		(property "Reference" "#PWR0291"
-			(at 436.88 339.09 0)
+			(at 394.97 364.49 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -102021,7 +112522,7 @@
 			)
 		)
 		(property "Value" "+3V"
-			(at 436.88 331.47 0)
+			(at 394.97 356.87 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -102029,7 +112530,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 436.88 335.28 0)
+			(at 394.97 360.68 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -102038,7 +112539,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 436.88 335.28 0)
+			(at 394.97 360.68 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -102047,7 +112548,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"+3V3\""
-			(at 436.88 335.28 0)
+			(at 394.97 360.68 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -102215,7 +112716,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "ebd7749c-38b6-4f02-ac2a-b261852f4a6e")
-		(property "Reference" "#PWR036"
+		(property "Reference" "#PWR36"
 			(at 318.77 406.4 0)
 			(effects
 				(font
@@ -102266,7 +112767,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR036")
+					(reference "#PWR36")
 					(unit 1)
 				)
 			)
@@ -102282,7 +112783,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "ec1f8076-30ae-4a11-86d3-943d97514646")
-		(property "Reference" "#PWR090"
+		(property "Reference" "#PWR90"
 			(at 220.98 214.63 0)
 			(effects
 				(font
@@ -102333,7 +112834,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR090")
+					(reference "#PWR90")
 					(unit 1)
 				)
 			)
@@ -102349,7 +112850,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "ecafe46a-c71e-4add-be1b-4b7c666ad082")
-		(property "Reference" "#PWR0326"
+		(property "Reference" "#PWR326"
 			(at 422.91 53.34 0)
 			(effects
 				(font
@@ -102400,7 +112901,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0326")
+					(reference "#PWR326")
 					(unit 1)
 				)
 			)
@@ -102408,7 +112909,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 763.27 320.04 0)
+		(at 660.4 320.04 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -102416,8 +112917,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "ee0c6b1a-92ed-42ac-93e9-bfb7997ebd6e")
-		(property "Reference" "#PWR0311"
-			(at 763.27 326.39 0)
+		(property "Reference" "#PWR311"
+			(at 660.4 326.39 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -102426,7 +112927,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 763.27 325.12 0)
+			(at 660.4 325.12 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -102435,7 +112936,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 763.27 320.04 0)
+			(at 660.4 320.04 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -102444,7 +112945,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 763.27 320.04 0)
+			(at 660.4 320.04 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -102453,7 +112954,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 763.27 320.04 0)
+			(at 660.4 320.04 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -102467,7 +112968,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0311")
+					(reference "#PWR311")
 					(unit 1)
 				)
 			)
@@ -102483,7 +112984,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "ef6f1310-f21c-4468-81ee-eded3163d238")
-		(property "Reference" "#PWR0302"
+		(property "Reference" "#PWR302"
 			(at 438.15 212.09 0)
 			(effects
 				(font
@@ -102534,7 +113035,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0302")
+					(reference "#PWR302")
 					(unit 1)
 				)
 			)
@@ -102542,7 +113043,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 554.99 403.86 0)
+		(at 674.37 392.43 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -102550,7 +113051,7 @@
 		(dnp no)
 		(uuid "ef8b82b4-8995-4b42-bc65-9fcb656f3d90")
 		(property "Reference" "C48"
-			(at 559.816 401.32 0)
+			(at 679.196 389.89 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -102558,7 +113059,7 @@
 			)
 		)
 		(property "Value" "100pF"
-			(at 560.324 403.86 0)
+			(at 679.704 392.43 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -102566,7 +113067,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 555.9552 407.67 0)
+			(at 675.3352 396.24 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -102575,7 +113076,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 554.99 403.86 0)
+			(at 674.37 392.43 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -102584,7 +113085,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 554.99 403.86 0)
+			(at 674.37 392.43 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -102609,7 +113110,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 562.61 208.28 0)
+		(at 621.03 226.06 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -102617,8 +113118,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "efd43329-32cc-478d-87ff-7d66dc267c06")
-		(property "Reference" "#PWR0310"
-			(at 562.61 214.63 0)
+		(property "Reference" "#PWR310"
+			(at 621.03 232.41 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -102627,7 +113128,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 562.61 213.36 0)
+			(at 621.03 231.14 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -102635,7 +113136,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 562.61 208.28 0)
+			(at 621.03 226.06 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -102644,7 +113145,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 562.61 208.28 0)
+			(at 621.03 226.06 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -102653,7 +113154,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 562.61 208.28 0)
+			(at 621.03 226.06 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -102667,7 +113168,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0310")
+					(reference "#PWR310")
 					(unit 1)
 				)
 			)
@@ -103164,7 +113665,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "f191e866-8f62-4fe3-aea7-e858efe64c43")
-		(property "Reference" "#PWR0203"
+		(property "Reference" "#PWR203"
 			(at 222.25 736.6 0)
 			(effects
 				(font
@@ -103214,7 +113715,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0203")
+					(reference "#PWR203")
 					(unit 1)
 				)
 			)
@@ -103230,7 +113731,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "f1b95885-85f0-472b-8c24-7f3cdce2bd24")
-		(property "Reference" "#PWR0102"
+		(property "Reference" "#PWR102"
 			(at 308.61 125.73 0)
 			(effects
 				(font
@@ -103281,7 +113782,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0102")
+					(reference "#PWR102")
 					(unit 1)
 				)
 			)
@@ -103434,7 +113935,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "f512e0dc-505d-49d4-bd2d-9336996360ba")
-		(property "Reference" "#PWR0334"
+		(property "Reference" "#PWR334"
 			(at 101.6 309.88 0)
 			(effects
 				(font
@@ -103484,7 +113985,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0334")
+					(reference "#PWR334")
 					(unit 1)
 				)
 			)
@@ -103500,7 +114001,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "f55ff11e-281b-4630-a4d8-225361753a7a")
-		(property "Reference" "#PWR0103"
+		(property "Reference" "#PWR103"
 			(at 308.61 151.13 0)
 			(effects
 				(font
@@ -103551,7 +114052,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0103")
+					(reference "#PWR103")
 					(unit 1)
 				)
 			)
@@ -103703,7 +114204,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "f6a6357b-3ee9-471b-b981-d08f86262b15")
-		(property "Reference" "#PWR0272"
+		(property "Reference" "#PWR272"
 			(at 615.95 129.54 0)
 			(effects
 				(font
@@ -103754,7 +114255,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0272")
+					(reference "#PWR272")
 					(unit 1)
 				)
 			)
@@ -103770,7 +114271,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "f6ca6114-0c60-44fc-a8b1-0c889ec1be9a")
-		(property "Reference" "#PWR079"
+		(property "Reference" "#PWR79"
 			(at 109.22 666.75 0)
 			(effects
 				(font
@@ -103820,7 +114321,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR079")
+					(reference "#PWR79")
 					(unit 1)
 				)
 			)
@@ -103836,7 +114337,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "f6d5c70f-a304-4119-93f5-b059c9cff2c2")
-		(property "Reference" "#PWR054"
+		(property "Reference" "#PWR54"
 			(at 1056.64 652.78 0)
 			(effects
 				(font
@@ -103886,7 +114387,7 @@
 		(instances
 			(project ""
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR054")
+					(reference "#PWR54")
 					(unit 1)
 				)
 			)
@@ -103903,7 +114404,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "f6e8c000-b3b5-4aa5-9efa-f7dcef241bb7")
-		(property "Reference" "#PWR0160"
+		(property "Reference" "#PWR160"
 			(at 82.55 45.72 0)
 			(effects
 				(font
@@ -103953,7 +114454,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0160")
+					(reference "#PWR160")
 					(unit 1)
 				)
 			)
@@ -104241,7 +114742,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "f902cc83-67fb-41f5-afc2-aa24004174c2")
-		(property "Reference" "#PWR0186"
+		(property "Reference" "#PWR186"
 			(at 121.92 152.4 0)
 			(effects
 				(font
@@ -104291,7 +114792,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0186")
+					(reference "#PWR186")
 					(unit 1)
 				)
 			)
@@ -104376,7 +114877,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "f9d9a2e7-b108-4654-8150-4938f69be22b")
-		(property "Reference" "#PWR013"
+		(property "Reference" "#PWR13"
 			(at 669.29 80.01 0)
 			(effects
 				(font
@@ -104427,7 +114928,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR013")
+					(reference "#PWR13")
 					(unit 1)
 				)
 			)
@@ -104573,7 +115074,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 685.8 234.95 0)
+		(at 758.19 234.95 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -104581,7 +115082,7 @@
 		(dnp no)
 		(uuid "fa774b03-8d6e-43cf-b948-d3bd98406d8a")
 		(property "Reference" "C155"
-			(at 678.942 232.918 0)
+			(at 751.332 232.918 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -104590,7 +115091,7 @@
 			)
 		)
 		(property "Value" "10pF"
-			(at 678.942 235.458 0)
+			(at 751.332 235.458 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -104599,7 +115100,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 686.7652 238.76 0)
+			(at 759.1552 238.76 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -104608,7 +115109,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 685.8 234.95 0)
+			(at 758.19 234.95 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -104617,7 +115118,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 685.8 234.95 0)
+			(at 758.19 234.95 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -104790,7 +115291,7 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "fbe12955-d847-456a-8116-7e50117c42b9")
-		(property "Reference" "#PWR0101"
+		(property "Reference" "#PWR101"
 			(at 308.61 92.71 0)
 			(effects
 				(font
@@ -104841,7 +115342,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0101")
+					(reference "#PWR101")
 					(unit 1)
 				)
 			)
@@ -104916,7 +115417,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 623.57 193.04 0)
+		(at 695.96 193.04 0)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -104924,8 +115425,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "fc02906c-043c-42a1-b200-7a3265dd0ca9")
-		(property "Reference" "#PWR0144"
-			(at 623.57 199.39 0)
+		(property "Reference" "#PWR144"
+			(at 695.96 199.39 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -104934,7 +115435,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 623.57 198.12 0)
+			(at 695.96 198.12 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -104942,7 +115443,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 623.57 193.04 0)
+			(at 695.96 193.04 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -104951,7 +115452,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 623.57 193.04 0)
+			(at 695.96 193.04 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -104960,7 +115461,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 623.57 193.04 0)
+			(at 695.96 193.04 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -104974,7 +115475,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0144")
+					(reference "#PWR144")
 					(unit 1)
 				)
 			)
@@ -105183,7 +115684,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 1094.74 341.63 270)
+		(at 1026.16 392.43 270)
 		(mirror x)
 		(unit 1)
 		(exclude_from_sim no)
@@ -105192,8 +115693,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "fcf5d343-0aab-44df-814e-a7292650387f")
-		(property "Reference" "#PWR026"
-			(at 1088.39 341.63 0)
+		(property "Reference" "#PWR26"
+			(at 1019.81 392.43 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -105202,7 +115703,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 1090.93 341.6299 90)
+			(at 1022.35 392.4299 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -105211,7 +115712,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 1094.74 341.63 0)
+			(at 1026.16 392.43 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -105220,7 +115721,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 1094.74 341.63 0)
+			(at 1026.16 392.43 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -105229,7 +115730,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 1094.74 341.63 0)
+			(at 1026.16 392.43 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -105243,7 +115744,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR026")
+					(reference "#PWR26")
 					(unit 1)
 				)
 			)
@@ -105251,7 +115752,7 @@
 	)
 	(symbol
 		(lib_id "Device:C")
-		(at 629.92 288.29 90)
+		(at 702.31 288.29 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -105259,7 +115760,7 @@
 		(dnp no)
 		(uuid "fdcaf2f7-d186-4adb-85ee-dd0d18a8c415")
 		(property "Reference" "C36"
-			(at 629.92 282.448 90)
+			(at 702.31 282.448 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -105267,7 +115768,7 @@
 			)
 		)
 		(property "Value" "1uF"
-			(at 629.92 284.226 90)
+			(at 702.31 284.226 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -105275,7 +115776,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 633.73 287.3248 0)
+			(at 706.12 287.3248 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -105284,7 +115785,7 @@
 			)
 		)
 		(property "Datasheet" "~"
-			(at 629.92 288.29 0)
+			(at 702.31 288.29 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -105293,7 +115794,7 @@
 			)
 		)
 		(property "Description" "Unpolarized capacitor"
-			(at 629.92 288.29 0)
+			(at 702.31 288.29 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -105318,7 +115819,7 @@
 	)
 	(symbol
 		(lib_id "power:GND")
-		(at 511.81 213.36 180)
+		(at 609.6 247.65 180)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -105326,8 +115827,8 @@
 		(dnp no)
 		(fields_autoplaced yes)
 		(uuid "fdfdde17-2385-4ecd-86ab-e660cf515345")
-		(property "Reference" "#PWR0242"
-			(at 511.81 207.01 0)
+		(property "Reference" "#PWR242"
+			(at 609.6 241.3 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -105336,7 +115837,7 @@
 			)
 		)
 		(property "Value" "GND"
-			(at 511.81 208.28 0)
+			(at 609.6 242.57 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -105344,7 +115845,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 511.81 213.36 0)
+			(at 609.6 247.65 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -105353,7 +115854,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 511.81 213.36 0)
+			(at 609.6 247.65 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -105362,7 +115863,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 511.81 213.36 0)
+			(at 609.6 247.65 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -105376,7 +115877,7 @@
 		(instances
 			(project "TransceiverPCB"
 				(path "/c3b39813-b92f-4147-9d23-d3b5683e1da6"
-					(reference "#PWR0242")
+					(reference "#PWR242")
 					(unit 1)
 				)
 			)
@@ -105451,7 +115952,7 @@
 	)
 	(symbol
 		(lib_id "power:+3V3")
-		(at 712.47 347.98 270)
+		(at 643.89 402.59 270)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
@@ -105460,7 +115961,7 @@
 		(fields_autoplaced yes)
 		(uuid "fe8e37f0-b688-4af7-96e1-c7a29c16d577")
 		(property "Reference" "#PWR0264"
-			(at 708.66 347.98 0)
+			(at 640.08 402.59 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -105469,7 +115970,7 @@
 			)
 		)
 		(property "Value" "+1V"
-			(at 716.28 347.9799 90)
+			(at 647.7 402.5899 90)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -105478,7 +115979,7 @@
 			)
 		)
 		(property "Footprint" ""
-			(at 712.47 347.98 0)
+			(at 643.89 402.59 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -105487,7 +115988,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 712.47 347.98 0)
+			(at 643.89 402.59 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -105496,7 +115997,7 @@
 			)
 		)
 		(property "Description" "Power symbol creates a global label with name \"+3V3\""
-			(at 712.47 347.98 0)
+			(at 643.89 402.59 0)
 			(effects
 				(font
 					(size 1.27 1.27)

--- a/TransceiverPCB/~TransceiverPCB.kicad_sch.lck
+++ b/TransceiverPCB/~TransceiverPCB.kicad_sch.lck
@@ -1,0 +1,1 @@
+{"hostname":"mac","username":"joaquincaraveo"}


### PR DESCRIPTION
Fixed ERC Errors:
-Changed IC footprints so that every GND pin is set to PASSIVE
- ADC Driver footprint VOCM pins set to inputs